### PR TITLE
feat(controller): add v8.1 multi-repository registry and request routing

### DIFF
--- a/.github/workflows/v81-diagnostics.yml
+++ b/.github/workflows/v81-diagnostics.yml
@@ -1,0 +1,32 @@
+name: V81 Diagnostics
+
+on:
+  pull_request:
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+      - run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run check:type 2>&1 | tee typecheck.log
+      - name: Focused tests
+        run: |
+          bun test --timeout 180000 \
+            tests/cli/repository-registry-v81.test.ts \
+            tests/cli/repository-migration-v81.test.ts \
+            tests/cli/multi-repository-routing-v81.test.ts \
+            2>&1 | tee focused-tests.log
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: v81-diagnostics
+          path: |
+            typecheck.log
+            focused-tests.log
+          if-no-files-found: ignore

--- a/.github/workflows/v81-diagnostics.yml
+++ b/.github/workflows/v81-diagnostics.yml
@@ -13,21 +13,15 @@ jobs:
           bun-version: 1.3.10
       - run: bun install --frozen-lockfile
       - name: Focused verification
+        shell: bash
         run: |
+          set -euo pipefail
           bun run check:type 2>&1 | tee typecheck.log
           bun test --timeout 180000 \
             tests/cli/repository-registry-v81.test.ts \
             tests/cli/repository-migration-v81.test.ts \
             tests/cli/multi-repository-routing-v81.test.ts \
             2>&1 | tee focused-tests.log
-      - name: Capture full CI gate
-        run: |
-          set +e
-          bun run check:ci > full-ci.log 2>&1
-          status=$?
-          echo "$status" > full-ci.exit
-          tail -n 100 full-ci.log
-          exit 0
       - name: Upload diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -36,6 +30,4 @@ jobs:
           path: |
             typecheck.log
             focused-tests.log
-            full-ci.log
-            full-ci.exit
           if-no-files-found: ignore

--- a/.github/workflows/v81-diagnostics.yml
+++ b/.github/workflows/v81-diagnostics.yml
@@ -12,15 +12,22 @@ jobs:
         with:
           bun-version: 1.3.10
       - run: bun install --frozen-lockfile
-      - name: Typecheck
-        run: bun run check:type 2>&1 | tee typecheck.log
-      - name: Focused tests
+      - name: Focused verification
         run: |
+          bun run check:type 2>&1 | tee typecheck.log
           bun test --timeout 180000 \
             tests/cli/repository-registry-v81.test.ts \
             tests/cli/repository-migration-v81.test.ts \
             tests/cli/multi-repository-routing-v81.test.ts \
             2>&1 | tee focused-tests.log
+      - name: Capture full CI gate
+        run: |
+          set +e
+          bun run check:ci > full-ci.log 2>&1
+          status=$?
+          echo "$status" > full-ci.exit
+          tail -n 100 full-ci.log
+          exit 0
       - name: Upload diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -29,4 +36,6 @@ jobs:
           path: |
             typecheck.log
             focused-tests.log
+            full-ci.log
+            full-ci.exit
           if-no-files-found: ignore

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "prepublishOnly": "bash scripts/check-npm-release.sh",
     "sync:brain-docs": "bash scripts/sync-brain-docs.sh --all",
     "sync:codex-installed": "bash scripts/sync-codex-installed-copies.sh",
-    "check:controller-v8": "bash scripts/verify-controller-v8.sh"
+    "check:controller-v8": "bash scripts/verify-controller-v8.sh",
+    "repo:registry": "bun src/cli/v81-entry.ts repo"
   },
   "devDependencies": {
     "@colbymchenry/codegraph": "1.0.1",

--- a/src/cli/agent-jobs/types.ts
+++ b/src/cli/agent-jobs/types.ts
@@ -51,7 +51,9 @@ export interface AgentJobEvent {
 }
 
 export interface AgentJobMeta {
-  schemaVersion: 1 | 2;
+  schemaVersion: 1 | 2 | 3;
+  repoId?: string;
+  checkoutId?: string;
   runId: string;
   issueId: string;
   taskId: string;
@@ -62,7 +64,9 @@ export interface AgentJobMeta {
   allowedPaths?: string[];
   status: AgentJobStatus;
   repoRoot: string;
+  executionRoot?: string;
   worktree: string;
+  worktreePath?: string;
   branch: string | null;
   baseRevision: string | null;
   promptPath: string;

--- a/src/cli/commands/repository.ts
+++ b/src/cli/commands/repository.ts
@@ -1,0 +1,108 @@
+import { Command } from 'commander';
+import { bindRepositoryEntities } from '../repositories/entity-migration';
+import {
+  disableRepository,
+  focusRepository,
+  getRepository,
+  getRepositoryFocus,
+  listRepositories,
+  refreshRepository,
+  registerRepository,
+  removeRepository,
+  repositorySummary,
+  updateRepository,
+  validateRepository,
+} from '../repositories/registry';
+
+function output(value: unknown, json: boolean): void {
+  if (json) console.log(JSON.stringify(value, null, 2));
+  else console.log(typeof value === 'string' ? value : JSON.stringify(value, null, 2));
+}
+
+function common(command: Command): Command {
+  return command
+    .option('--controller-home <path>', 'Controller global data directory')
+    .option('--json', 'Output JSON');
+}
+
+export function buildRepositoryCommand(): Command {
+  const command = new Command('repo').description('Register and inspect repositories managed by the global Controller');
+
+  common(command.command('register')
+    .description('Register a Git repository without relying on the Controller startup directory')
+    .argument('<path>', 'Repository checkout path')
+    .option('--name <display-name>', 'Display name')
+    .option('--remote <url>', 'Override remote URL')
+    .option('--default-branch <branch>', 'Override default branch'))
+    .action((path: string, opts: { controllerHome?: string; name?: string; remote?: string; defaultBranch?: string; json?: boolean }) => {
+      const repository = registerRepository({
+        path,
+        controllerHome: opts.controllerHome,
+        displayName: opts.name,
+        remoteUrl: opts.remote,
+        defaultBranch: opts.defaultBranch,
+      });
+      const migration = bindRepositoryEntities(repository);
+      output({ repository, migration }, opts.json === true);
+    });
+
+  common(command.command('list').description('List registered repositories')
+    .option('--all', 'Include removed audit records'))
+    .action((opts: { controllerHome?: string; all?: boolean; json?: boolean }) => {
+      const repositories = listRepositories(opts.controllerHome, { includeRemoved: opts.all === true });
+      output({ repositories: repositories.map(repositorySummary), focus: getRepositoryFocus(opts.controllerHome) }, opts.json === true);
+    });
+
+  common(command.command('inspect').description('Inspect one repository')
+    .argument('<repo-id>', 'Stable repository ID'))
+    .action((repoId: string, opts: { controllerHome?: string; json?: boolean }) => {
+      output(getRepository(repoId, opts.controllerHome, { includeRemoved: true }), opts.json === true);
+    });
+
+  common(command.command('validate').description('Validate checkout identity and migrate legacy entities')
+    .argument('<repo-id>', 'Stable repository ID'))
+    .action((repoId: string, opts: { controllerHome?: string; json?: boolean }) => {
+      const repository = getRepository(repoId, opts.controllerHome, { includeRemoved: true });
+      output({ validation: validateRepository(repoId, opts.controllerHome), migration: bindRepositoryEntities(repository) }, opts.json === true);
+    });
+
+  common(command.command('update').description('Update repository metadata')
+    .argument('<repo-id>', 'Stable repository ID')
+    .option('--name <display-name>', 'Display name')
+    .option('--default-branch <branch>', 'Default branch')
+    .option('--enable', 'Enable repository'))
+    .action((repoId: string, opts: { controllerHome?: string; name?: string; defaultBranch?: string; enable?: boolean; json?: boolean }) => {
+      output(updateRepository(repoId, {
+        displayName: opts.name,
+        defaultBranch: opts.defaultBranch,
+        enabled: opts.enable === true ? true : undefined,
+      }, opts.controllerHome), opts.json === true);
+    });
+
+  common(command.command('refresh').description('Refresh Git and remote metadata')
+    .argument('<repo-id>', 'Stable repository ID'))
+    .action((repoId: string, opts: { controllerHome?: string; json?: boolean }) => {
+      const repository = refreshRepository(repoId, opts.controllerHome);
+      output({ repository, migration: bindRepositoryEntities(repository) }, opts.json === true);
+    });
+
+  common(command.command('disable').description('Disable new execution while retaining history')
+    .argument('<repo-id>', 'Stable repository ID'))
+    .action((repoId: string, opts: { controllerHome?: string; json?: boolean }) => {
+      output(disableRepository(repoId, opts.controllerHome), opts.json === true);
+    });
+
+  common(command.command('remove').description('Soft-remove a repository while retaining Controller audit state')
+    .argument('<repo-id>', 'Stable repository ID'))
+    .action((repoId: string, opts: { controllerHome?: string; json?: boolean }) => {
+      output(removeRepository(repoId, opts.controllerHome), opts.json === true);
+    });
+
+  common(command.command('focus').description('Set an interactive UI preference; never used as an execution security boundary')
+    .argument('[repo-id]', 'Stable repository ID; omit to clear focus'))
+    .action((repoId: string | undefined, opts: { controllerHome?: string; json?: boolean }) => {
+      output(focusRepository(repoId, opts.controllerHome), opts.json === true);
+    });
+
+  return command;
+}

--- a/src/cli/controller/types.ts
+++ b/src/cli/controller/types.ts
@@ -30,6 +30,7 @@ export interface TaskCommandEvidence {
 }
 
 export interface TaskVerification {
+  repoId?: string;
   runId?: string;
   integratedRevision?: string;
   reviewedDiffHash?: string;
@@ -42,6 +43,7 @@ export interface TaskVerification {
 }
 
 export interface ControllerTask {
+  repoId?: string;
   id: string;
   title: string;
   objective: string;
@@ -64,7 +66,8 @@ export interface ControllerTask {
 }
 
 export interface ControllerIssue {
-  schemaVersion: 1 | 2 | 3 | 4 | 5;
+  schemaVersion: 1 | 2 | 3 | 4 | 5 | 6;
+  repoId?: string;
   id: string;
   title: string;
   slug: string;
@@ -85,6 +88,7 @@ export interface ControllerIssue {
 }
 
 export interface TaskDraft {
+  repoId?: string;
   title: string;
   objective: string;
   dependsOn?: string[];

--- a/src/cli/mcp/legacy-context.ts
+++ b/src/cli/mcp/legacy-context.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'path';
+import { getMcpPolicy, parseMcpProfile } from './policy';
+import type { McpToolContext } from './tools';
+import type { McpServerOptions } from './multi-repository';
+
+export function createLegacyMcpToolContext(opts: McpServerOptions): McpToolContext {
+  const repoRoot = resolve(opts.repo?.trim() || '.');
+  return {
+    repoRoot,
+    policy: getMcpPolicy(parseMcpProfile(opts.profile ?? 'planner'), { repoRoot }),
+    enableChatgptBrowser: opts.enableChatgptBrowser === true,
+  };
+}

--- a/src/cli/mcp/multi-repository.ts
+++ b/src/cli/mcp/multi-repository.ts
@@ -1,0 +1,192 @@
+import { loadMcpLocalConfig } from './auth';
+import { getMcpPolicy, parseMcpProfile } from './policy';
+import { buildMcpToolDefinitions, callMcpTool, type McpToolContext, type McpToolDefinition } from './tools';
+import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_TIMEOUT_MS, normalizeAgentTimeoutMs } from '../controller/runtime-config';
+import type { McpAgentRunnerName } from './types';
+import { ensureControllerHome } from '../repositories/controller-home';
+import { bindRepositoryEntities } from '../repositories/entity-migration';
+import { registerRepository, repositorySummary, resolveRepositorySelection } from '../repositories/registry';
+import type { RepositoryRecord } from '../repositories/types';
+
+export interface McpServerOptions {
+  repo?: string;
+  controllerHome?: string;
+  profile?: string;
+  enableChatgptBrowser?: boolean;
+  enableDevRunner?: boolean;
+  devRunnerAgents?: string;
+  devRunnerTimeoutMs?: number;
+  devRunnerMaxTimeoutMs?: number;
+}
+
+export interface MultiRepositoryMcpToolContext extends McpToolContext {
+  controllerHome: string;
+  explicitRepository?: RepositoryRecord;
+}
+
+interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+function parseBooleanSetting(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return undefined;
+}
+
+function parseAgentList(value: unknown): McpAgentRunnerName[] {
+  const raw = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : [];
+  return Array.from(new Set(raw
+    .map((entry) => String(entry).trim().toLowerCase())
+    .filter((entry): entry is McpAgentRunnerName => entry === 'codex' || entry === 'claude')));
+}
+
+function runtimePolicy(repoRoot: string, opts: McpServerOptions) {
+  const profile = parseMcpProfile(opts.profile ?? 'controller');
+  const config = loadMcpLocalConfig(repoRoot);
+  const envDevRunner = parseBooleanSetting(process.env.REPO_HARNESS_MCP_DEV_RUNNER);
+  const configuredDevRunner = envDevRunner ?? config?.devMode?.agentRunner === true;
+  const devAgentRunner = opts.enableDevRunner === true || configuredDevRunner;
+  const allowedAgents = parseAgentList(
+    opts.devRunnerAgents ?? process.env.REPO_HARNESS_MCP_DEV_RUNNER_AGENTS ?? config?.devMode?.allowedAgents,
+  );
+  const runnerMaxTimeoutMs = normalizeAgentTimeoutMs(
+    opts.devRunnerMaxTimeoutMs ?? process.env.REPO_HARNESS_MCP_DEV_RUNNER_MAX_TIMEOUT_MS ?? config?.devMode?.maxTimeoutMs,
+    { defaultMs: MAX_AGENT_TIMEOUT_MS, maxMs: MAX_AGENT_TIMEOUT_MS, label: 'dev runner max timeout' },
+  );
+  const runnerTimeoutMs = normalizeAgentTimeoutMs(
+    opts.devRunnerTimeoutMs ?? process.env.REPO_HARNESS_MCP_DEV_RUNNER_TIMEOUT_MS ?? config?.devMode?.timeoutMs,
+    { defaultMs: DEFAULT_AGENT_TIMEOUT_MS, maxMs: runnerMaxTimeoutMs, label: 'dev runner timeout' },
+  );
+  return getMcpPolicy(profile, {
+    devAgentRunner,
+    allowedAgents,
+    runnerTimeoutMs,
+    runnerMaxTimeoutMs,
+    repoRoot,
+  });
+}
+
+function injectRepositoryContext(tool: McpToolDefinition): McpToolDefinition {
+  const schema = tool.inputSchema as {
+    type?: unknown;
+    properties?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  if (schema.type !== 'object') return tool;
+  return {
+    ...tool,
+    inputSchema: {
+      ...schema,
+      properties: {
+        repo_id: {
+          type: 'string',
+          description: 'Stable repoId. Required when more than one repository is enabled.',
+        },
+        checkout_id: {
+          type: 'string',
+          description: 'Checkout identity for repositories with multiple local clones.',
+        },
+        ...(schema.properties ?? {}),
+      },
+    },
+  };
+}
+
+export function buildMultiRepositoryToolDefinitions(
+  ctx: MultiRepositoryMcpToolContext,
+): McpToolDefinition[] {
+  return buildMcpToolDefinitions(ctx.policy, {
+    enableChatgptBrowser: ctx.enableChatgptBrowser === true,
+  }).map(injectRepositoryContext);
+}
+
+function errorResult(error: unknown): ToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = message.includes(':') ? message.slice(0, message.indexOf(':')) : 'TOOL_FAILED';
+  const value = { error: { code, message } };
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+    isError: true,
+  };
+}
+
+function withRepositoryEnvelope(result: ToolResult, repository: RepositoryRecord): ToolResult {
+  const summary = repositorySummary(repository);
+  if (result.structuredContent && typeof result.structuredContent === 'object' && !Array.isArray(result.structuredContent)) {
+    const structuredContent = {
+      ...(result.structuredContent as Record<string, unknown>),
+      repoId: repository.repoId,
+      repository: summary,
+    };
+    return {
+      ...result,
+      structuredContent,
+      content: [{ type: 'text', text: JSON.stringify(structuredContent, null, 2) }],
+    };
+  }
+  return {
+    ...result,
+    content: [
+      ...result.content,
+      { type: 'text', text: JSON.stringify({ repoId: repository.repoId, repository: summary }, null, 2) },
+    ],
+  };
+}
+
+export function createMcpToolContext(opts: McpServerOptions): MultiRepositoryMcpToolContext {
+  const controllerHome = ensureControllerHome(opts.controllerHome);
+  const explicitRepository = opts.repo?.trim()
+    ? registerRepository({ path: opts.repo, controllerHome })
+    : undefined;
+  const policyRoot = explicitRepository?.canonicalRoot ?? controllerHome;
+  return {
+    controllerHome,
+    explicitRepository,
+    repoRoot: policyRoot,
+    policy: runtimePolicy(policyRoot, opts),
+    enableChatgptBrowser: opts.enableChatgptBrowser === true,
+  };
+}
+
+export async function callMultiRepositoryTool(
+  ctx: MultiRepositoryMcpToolContext,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<ToolResult> {
+  try {
+    const repository = resolveRepositorySelection({
+      repoId: typeof args.repo_id === 'string' ? args.repo_id : undefined,
+      checkoutId: typeof args.checkout_id === 'string' ? args.checkout_id : undefined,
+      explicitPath: ctx.explicitRepository?.canonicalRoot,
+      controllerHome: ctx.controllerHome,
+      allowSoleRepository: true,
+    });
+    const scopedArgs = { ...args };
+    delete scopedArgs.repo_id;
+    delete scopedArgs.checkout_id;
+    bindRepositoryEntities(repository);
+    const scopedContext: McpToolContext = {
+      repoRoot: repository.canonicalRoot,
+      policy: runtimePolicy(repository.canonicalRoot, {
+        profile: ctx.policy.profile,
+        enableChatgptBrowser: ctx.enableChatgptBrowser,
+        enableDevRunner: ctx.policy.execution.agentRunner,
+        devRunnerAgents: ctx.policy.execution.allowedAgents.join(','),
+        devRunnerTimeoutMs: ctx.policy.execution.runnerTimeoutMs,
+        devRunnerMaxTimeoutMs: ctx.policy.execution.runnerMaxTimeoutMs,
+      }),
+      enableChatgptBrowser: ctx.enableChatgptBrowser,
+    };
+    const result = await callMcpTool(scopedContext, name, scopedArgs) as ToolResult;
+    bindRepositoryEntities(repository);
+    return withRepositoryEnvelope(result, repository);
+  } catch (error) {
+    return errorResult(error);
+  }
+}

--- a/src/cli/mcp/repository-tools.ts
+++ b/src/cli/mcp/repository-tools.ts
@@ -1,0 +1,146 @@
+import { bindRepositoryEntities } from '../repositories/entity-migration';
+import {
+  disableRepository,
+  getRepository,
+  listRepositories,
+  refreshRepository,
+  registerRepository,
+  removeRepository,
+  repositorySummary,
+  updateRepository,
+  validateRepository,
+} from '../repositories/registry';
+import type { McpToolDefinition } from './tools';
+
+export interface RepositoryToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+function definition(
+  name: string,
+  description: string,
+  properties: Record<string, unknown>,
+  required: string[] = [],
+  destructiveHint = false,
+): McpToolDefinition {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: 'object',
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint },
+  };
+}
+
+const repoId = { type: 'string', description: 'Stable Repository Registry repoId.' };
+
+export const repositoryToolDefinitions: McpToolDefinition[] = [
+  definition('repository_register', 'Register a Git repository with the Controller.', {
+    path: { type: 'string' },
+    display_name: { type: 'string' },
+    remote_url: { type: 'string' },
+    default_branch: { type: 'string' },
+  }, ['path']),
+  definition('repository_list', 'List registered repositories.', {
+    include_removed: { type: 'boolean' },
+  }),
+  definition('repository_get', 'Inspect one registered repository.', {
+    repo_id: repoId,
+    include_removed: { type: 'boolean' },
+  }, ['repo_id']),
+  definition('repository_validate', 'Validate repository identity and migrate legacy ownership.', {
+    repo_id: repoId,
+  }, ['repo_id']),
+  definition('repository_refresh', 'Refresh repository Git and checkout metadata.', {
+    repo_id: repoId,
+  }, ['repo_id']),
+  definition('repository_update', 'Update mutable repository metadata.', {
+    repo_id: repoId,
+    display_name: { type: 'string' },
+    default_branch: { type: 'string' },
+    enabled: { type: 'boolean' },
+  }, ['repo_id']),
+  definition('repository_disable', 'Disable new execution while retaining audit history.', {
+    repo_id: repoId,
+  }, ['repo_id']),
+  definition('repository_remove', 'Soft-remove a repository while retaining audit history.', {
+    repo_id: repoId,
+  }, ['repo_id'], true),
+];
+
+function result(value: Record<string, unknown>): RepositoryToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+  };
+}
+
+function failure(error: unknown): RepositoryToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = message.includes(':') ? message.slice(0, message.indexOf(':')) : 'REPOSITORY_TOOL_FAILED';
+  return { ...result({ error: { code, message } }), isError: true };
+}
+
+export function callRepositoryTool(
+  controllerHome: string,
+  name: string,
+  args: Record<string, unknown>,
+): RepositoryToolResult | undefined {
+  if (!name.startsWith('repository_')) return undefined;
+  try {
+    const repoIdValue = typeof args.repo_id === 'string' ? args.repo_id.trim() : '';
+    switch (name) {
+      case 'repository_register': {
+        const repository = registerRepository({
+          path: String(args.path ?? ''),
+          controllerHome,
+          displayName: typeof args.display_name === 'string' ? args.display_name : undefined,
+          remoteUrl: typeof args.remote_url === 'string' ? args.remote_url : undefined,
+          defaultBranch: typeof args.default_branch === 'string' ? args.default_branch : undefined,
+        });
+        return result({ repository, migration: bindRepositoryEntities(repository) });
+      }
+      case 'repository_list':
+        return result({
+          repositories: listRepositories(controllerHome, {
+            includeRemoved: args.include_removed === true,
+          }).map(repositorySummary),
+        });
+      case 'repository_get':
+        return result({ repository: getRepository(repoIdValue, controllerHome, {
+          includeRemoved: args.include_removed === true,
+        }) });
+      case 'repository_validate': {
+        const repository = getRepository(repoIdValue, controllerHome, { includeRemoved: true });
+        return result({
+          validation: validateRepository(repoIdValue, controllerHome),
+          migration: bindRepositoryEntities(repository),
+        });
+      }
+      case 'repository_refresh': {
+        const repository = refreshRepository(repoIdValue, controllerHome);
+        return result({ repository, migration: bindRepositoryEntities(repository) });
+      }
+      case 'repository_update':
+        return result({ repository: updateRepository(repoIdValue, {
+          displayName: typeof args.display_name === 'string' ? args.display_name : undefined,
+          defaultBranch: typeof args.default_branch === 'string' ? args.default_branch : undefined,
+          enabled: typeof args.enabled === 'boolean' ? args.enabled : undefined,
+        }, controllerHome) });
+      case 'repository_disable':
+        return result({ repository: disableRepository(repoIdValue, controllerHome) });
+      case 'repository_remove':
+        return result({ repository: removeRepository(repoIdValue, controllerHome) });
+      default:
+        return failure(new Error(`UNKNOWN_REPOSITORY_TOOL: ${name}`));
+    }
+  } catch (error) {
+    return failure(error);
+  }
+}

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -1,80 +1,20 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { loadMcpLocalConfig } from './auth';
 import { mcpServerInstructions } from './instructions';
-import { getMcpPolicy, parseMcpProfile } from './policy';
-import { resolveMcpRepoRoot } from './repo';
-import { buildMcpToolDefinitions, callMcpTool, type McpToolContext } from './tools';
-import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_TIMEOUT_MS, normalizeAgentTimeoutMs } from '../controller/runtime-config';
-import type { McpAgentRunnerName } from './types';
+import {
+  buildMultiRepositoryToolDefinitions,
+  callMultiRepositoryTool,
+  createMcpToolContext,
+  type McpServerOptions,
+} from './multi-repository';
 
-export interface McpServerOptions {
-  repo?: string;
-  profile?: string;
-  enableChatgptBrowser?: boolean;
-  enableDevRunner?: boolean;
-  devRunnerAgents?: string;
-  devRunnerTimeoutMs?: number;
-  devRunnerMaxTimeoutMs?: number;
-}
-
-function parseBooleanSetting(value: string | undefined): boolean | undefined {
-  if (value === undefined) return undefined;
-  const normalized = value.trim().toLowerCase();
-  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-  return undefined;
-}
-
-function parseAgentList(value: unknown): McpAgentRunnerName[] {
-  const raw = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : [];
-  return Array.from(new Set(raw
-    .map((entry) => String(entry).trim().toLowerCase())
-    .filter((entry): entry is McpAgentRunnerName => entry === 'codex' || entry === 'claude')));
-}
-
-function parseTimeoutMs(value: unknown, fallback: number, maxMs: number): number {
-  return normalizeAgentTimeoutMs(value, { defaultMs: fallback, maxMs, label: 'dev runner timeout' });
-}
-
-
-export function createMcpToolContext(opts: McpServerOptions): McpToolContext {
-  const profile = parseMcpProfile(opts.profile ?? 'controller');
-  const repoRoot = resolveMcpRepoRoot(opts.repo ?? '.');
-  const config = loadMcpLocalConfig(repoRoot);
-  const envDevRunner = parseBooleanSetting(process.env.REPO_HARNESS_MCP_DEV_RUNNER);
-  const configuredDevRunner = envDevRunner ?? config?.devMode?.agentRunner === true;
-  const devAgentRunner = opts.enableDevRunner === true || configuredDevRunner;
-  const allowedAgents = parseAgentList(
-    opts.devRunnerAgents ?? process.env.REPO_HARNESS_MCP_DEV_RUNNER_AGENTS ?? config?.devMode?.allowedAgents,
-  );
-  const runnerMaxTimeoutMs = parseTimeoutMs(
-    opts.devRunnerMaxTimeoutMs ?? process.env.REPO_HARNESS_MCP_DEV_RUNNER_MAX_TIMEOUT_MS ?? config?.devMode?.maxTimeoutMs,
-    MAX_AGENT_TIMEOUT_MS,
-    MAX_AGENT_TIMEOUT_MS,
-  );
-  const runnerTimeoutMs = parseTimeoutMs(
-    opts.devRunnerTimeoutMs ?? process.env.REPO_HARNESS_MCP_DEV_RUNNER_TIMEOUT_MS ?? config?.devMode?.timeoutMs,
-    DEFAULT_AGENT_TIMEOUT_MS,
-    runnerMaxTimeoutMs,
-  );
-  return {
-    repoRoot,
-    policy: getMcpPolicy(profile, {
-      devAgentRunner,
-      allowedAgents,
-      runnerTimeoutMs,
-      runnerMaxTimeoutMs,
-      repoRoot,
-    }),
-    enableChatgptBrowser: opts.enableChatgptBrowser === true,
-  };
-}
+export type { McpServerOptions } from './multi-repository';
+export { buildMultiRepositoryToolDefinitions, callMultiRepositoryTool, createMcpToolContext } from './multi-repository';
 
 export function createRepoHarnessMcpServer(opts: McpServerOptions): Server {
   const ctx = createMcpToolContext(opts);
   const server = new Server(
-    { name: 'repo-harness-mcp', version: '1.3.0' },
+    { name: 'repo-harness-mcp', version: '1.4.0' },
     {
       capabilities: { tools: {} },
       instructions: mcpServerInstructions(ctx.policy.profile),
@@ -82,13 +22,13 @@ export function createRepoHarnessMcpServer(opts: McpServerOptions): Server {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: buildMcpToolDefinitions(ctx.policy, { enableChatgptBrowser: ctx.enableChatgptBrowser === true }),
+    tools: buildMultiRepositoryToolDefinitions(ctx),
   }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request: { params: { name: string; arguments?: unknown } }) => {
     const name = request.params.name;
     const args = (request.params.arguments ?? {}) as Record<string, unknown>;
-    return callMcpTool(ctx, name, args);
+    return callMultiRepositoryTool(ctx, name, args);
   });
 
   return server;

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -7,6 +7,7 @@ import {
   createMcpToolContext as createMultiRepositoryToolContext,
   type McpServerOptions,
 } from './multi-repository';
+import { callRepositoryTool, repositoryToolDefinitions } from './repository-tools';
 
 export type { McpServerOptions } from './multi-repository';
 export { buildMultiRepositoryToolDefinitions, callMultiRepositoryTool } from './multi-repository';
@@ -24,11 +25,13 @@ export function createRepoHarnessMcpServer(opts: McpServerOptions): Server {
     { capabilities: { tools: {} }, instructions: mcpServerInstructions(ctx.policy.profile) },
   );
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: buildMultiRepositoryToolDefinitions(ctx),
+    tools: repositoryToolDefinitions.concat(buildMultiRepositoryToolDefinitions(ctx)),
   }));
   server.setRequestHandler(CallToolRequestSchema, async (request: { params: { name: string; arguments?: unknown } }) => {
     const name = request.params.name;
     const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+    const repositoryResult = callRepositoryTool(ctx.controllerHome, name, args);
+    if (repositoryResult) return repositoryResult;
     return callMultiRepositoryTool(ctx, name, args);
   });
   return server;

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -4,32 +4,32 @@ import { mcpServerInstructions } from './instructions';
 import {
   buildMultiRepositoryToolDefinitions,
   callMultiRepositoryTool,
-  createMcpToolContext,
+  createMcpToolContext as createMultiRepositoryToolContext,
   type McpServerOptions,
 } from './multi-repository';
 
 export type { McpServerOptions } from './multi-repository';
-export { buildMultiRepositoryToolDefinitions, callMultiRepositoryTool, createMcpToolContext } from './multi-repository';
+export { buildMultiRepositoryToolDefinitions, callMultiRepositoryTool } from './multi-repository';
+
+export function createMcpToolContext(opts: McpServerOptions) {
+  const profile = opts.profile ?? 'controller';
+  const repo = profile === 'controller' && opts.repo?.trim() === '.' ? undefined : opts.repo;
+  return createMultiRepositoryToolContext({ ...opts, repo });
+}
 
 export function createRepoHarnessMcpServer(opts: McpServerOptions): Server {
   const ctx = createMcpToolContext(opts);
   const server = new Server(
     { name: 'repo-harness-mcp', version: '1.4.0' },
-    {
-      capabilities: { tools: {} },
-      instructions: mcpServerInstructions(ctx.policy.profile),
-    },
+    { capabilities: { tools: {} }, instructions: mcpServerInstructions(ctx.policy.profile) },
   );
-
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: buildMultiRepositoryToolDefinitions(ctx),
   }));
-
   server.setRequestHandler(CallToolRequestSchema, async (request: { params: { name: string; arguments?: unknown } }) => {
     const name = request.params.name;
     const args = (request.params.arguments ?? {}) as Record<string, unknown>;
     return callMultiRepositoryTool(ctx, name, args);
   });
-
   return server;
 }

--- a/src/cli/repositories/controller-home.ts
+++ b/src/cli/repositories/controller-home.ts
@@ -1,0 +1,32 @@
+import { mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join, resolve } from 'path';
+
+export function resolveControllerHome(explicit?: string): string {
+  const configured = explicit?.trim()
+    || process.env.REPO_HARNESS_CONTROLLER_HOME?.trim()
+    || (process.env.XDG_STATE_HOME?.trim()
+      ? join(process.env.XDG_STATE_HOME.trim(), 'repo-harness', 'controller')
+      : join(homedir(), '.repo-harness', 'controller'));
+  return resolve(configured);
+}
+
+export function ensureControllerHome(explicit?: string): string {
+  const home = resolveControllerHome(explicit);
+  for (const child of ['', 'repositories', 'locks', 'indexes', 'audit']) {
+    mkdirSync(join(home, child), { recursive: true });
+  }
+  return home;
+}
+
+export function repositoryControllerRoot(controllerHome: string, repoId: string): string {
+  return join(resolveControllerHome(controllerHome), 'repositories', repoId);
+}
+
+export function ensureRepositoryControllerLayout(controllerHome: string, repoId: string): string {
+  const root = repositoryControllerRoot(controllerHome, repoId);
+  for (const child of ['', 'runs', 'worktrees', 'artifacts', 'locks', 'indexes', 'jobs']) {
+    mkdirSync(join(root, child), { recursive: true });
+  }
+  return root;
+}

--- a/src/cli/repositories/entity-migration.ts
+++ b/src/cli/repositories/entity-migration.ts
@@ -1,0 +1,178 @@
+import { existsSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from 'fs';
+import { dirname, join, relative } from 'path';
+import type { EntityMigrationReport, RepositoryRecord } from './types';
+
+function atomicJson(path: string, value: unknown): void {
+  const temp = join(dirname(path), `.${path.split(/[\\/]/).at(-1)}.${process.pid}.${Date.now()}.tmp`);
+  writeFileSync(temp, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  renameSync(temp, path);
+}
+
+function listFiles(root: string, relativeRoot: string, predicate: (path: string) => boolean): string[] {
+  const absolute = join(root, relativeRoot);
+  if (!existsSync(absolute)) return [];
+  const result: string[] = [];
+  const visit = (path: string): void => {
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      for (const name of readdirSync(path)) visit(join(path, name));
+    } else if (stat.isFile() && predicate(path)) {
+      result.push(path);
+    }
+  };
+  visit(absolute);
+  return result;
+}
+
+function bindOwnedField(value: Record<string, unknown>, key: string, expected: string, label: string): boolean {
+  const current = value[key];
+  if (current === undefined || current === null || current === '') {
+    value[key] = expected;
+    return true;
+  }
+  if (current !== expected) {
+    throw new Error(`${label} is already bound to ${String(current)} and cannot be rebound to ${expected}`);
+  }
+  return false;
+}
+
+function bindIssue(value: Record<string, unknown>, record: RepositoryRecord): boolean {
+  let changed = bindOwnedField(value, 'repoId', record.repoId, 'Issue');
+  const tasks = Array.isArray(value.tasks) ? value.tasks : [];
+  for (const task of tasks) {
+    if (!task || typeof task !== 'object') continue;
+    const target = task as Record<string, unknown>;
+    changed = bindOwnedField(target, 'repoId', record.repoId, `Task ${String(target.id ?? 'unknown')}`) || changed;
+    const verification = target.verification;
+    if (verification && typeof verification === 'object') {
+      changed = bindOwnedField(verification as Record<string, unknown>, 'repoId', record.repoId, `Verification for ${String(target.id ?? 'unknown')}`) || changed;
+    }
+  }
+  return changed;
+}
+
+function inferredCheckoutId(value: Record<string, unknown>, record: RepositoryRecord, label: string): string {
+  const existing = typeof value.checkoutId === 'string' ? value.checkoutId.trim() : '';
+  if (existing) {
+    if (!record.checkouts.some((checkout) => checkout.checkoutId === existing)) {
+      throw new Error(`${label} references unknown checkout ${existing}`);
+    }
+    return existing;
+  }
+  const repoRoot = typeof value.repoRoot === 'string' ? value.repoRoot : undefined;
+  const matched = repoRoot
+    ? record.checkouts.find((checkout) => checkout.canonicalRoot === repoRoot || checkout.localRoot === repoRoot)
+    : undefined;
+  if (matched) return matched.checkoutId;
+  if (record.checkouts.length === 1) return record.checkouts[0].checkoutId;
+  throw new Error(`${label} has no checkoutId and cannot be inferred across ${record.checkouts.length} checkouts`);
+}
+
+function bindRun(value: Record<string, unknown>, record: RepositoryRecord): boolean {
+  let changed = bindOwnedField(value, 'repoId', record.repoId, `Run ${String(value.runId ?? 'unknown')}`);
+  const checkoutId = inferredCheckoutId(value, record, `Run ${String(value.runId ?? 'unknown')}`);
+  if (value.checkoutId !== checkoutId) {
+    value.checkoutId = checkoutId;
+    changed = true;
+  }
+  const checkout = record.checkouts.find((candidate) => candidate.checkoutId === checkoutId)!;
+  if (value.repoRoot === undefined || value.repoRoot === null || value.repoRoot === '') {
+    value.repoRoot = checkout.canonicalRoot;
+    changed = true;
+  }
+  const executionRoot = typeof value.worktree === 'string' && value.worktree
+    ? value.worktree
+    : typeof value.repoRoot === 'string' && value.repoRoot
+      ? value.repoRoot
+      : checkout.canonicalRoot;
+  if (value.executionRoot === undefined || value.executionRoot === null || value.executionRoot === '') {
+    value.executionRoot = executionRoot;
+    changed = true;
+  }
+  if (value.worktreePath === undefined || value.worktreePath === null || value.worktreePath === '') {
+    value.worktreePath = executionRoot;
+    changed = true;
+  }
+  return changed;
+}
+
+function bindEditSession(value: Record<string, unknown>, record: RepositoryRecord): boolean {
+  let changed = bindOwnedField(value, 'repoId', record.repoId, `Edit Session ${String(value.sessionId ?? 'unknown')}`);
+  const checkoutId = inferredCheckoutId(value, record, `Edit Session ${String(value.sessionId ?? 'unknown')}`);
+  if (value.checkoutId !== checkoutId) {
+    value.checkoutId = checkoutId;
+    changed = true;
+  }
+  return changed;
+}
+
+function migrateJsonFile(path: string, record: RepositoryRecord, kind: 'issue' | 'run' | 'edit'): boolean {
+  const value = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+  const changed = kind === 'issue'
+    ? bindIssue(value, record)
+    : kind === 'run'
+      ? bindRun(value, record)
+      : bindEditSession(value, record);
+  if (changed) atomicJson(path, value);
+  return changed;
+}
+
+function migrateJsonl(path: string, record: RepositoryRecord): boolean {
+  const raw = readFileSync(path, 'utf-8');
+  let changed = false;
+  const output = raw.split(/\r?\n/).map((line: string) => {
+    if (!line.trim()) return line;
+    const value = JSON.parse(line) as Record<string, unknown>;
+    changed = bindOwnedField(value, 'repoId', record.repoId, 'Worklog event') || changed;
+    return JSON.stringify(value);
+  }).join('\n');
+  if (changed) writeFileSync(path, output, 'utf-8');
+  return changed;
+}
+
+export function bindRepositoryEntities(record: RepositoryRecord): EntityMigrationReport {
+  const report: EntityMigrationReport = {
+    repoId: record.repoId,
+    checkoutId: record.activeCheckoutId,
+    scanned: 0,
+    updated: 0,
+    unresolved: 0,
+    files: [],
+    errors: [],
+  };
+  const roots: Array<{ root: string; kind: 'issue' | 'run' | 'edit'; predicate: (path: string) => boolean }> = [
+    { root: 'tasks/issues', kind: 'issue', predicate: (path) => path.endsWith('.issue.json') },
+    { root: '.ai/harness/ephemeral-issues', kind: 'issue', predicate: (path) => path.endsWith('.issue.json') },
+    { root: '.ai/harness/jobs', kind: 'run', predicate: (path) => path.endsWith('/meta.json') || path.endsWith('\\meta.json') },
+    { root: '.ai/harness/edit-sessions', kind: 'edit', predicate: (path) => path.endsWith('/session.json') || path.endsWith('\\session.json') },
+  ];
+  for (const entry of roots) {
+    for (const path of listFiles(record.canonicalRoot, entry.root, entry.predicate)) {
+      report.scanned += 1;
+      try {
+        if (migrateJsonFile(path, record, entry.kind)) {
+          report.updated += 1;
+          report.files.push(relative(record.canonicalRoot, path).replace(/\\/g, '/'));
+        }
+      } catch (error) {
+        report.unresolved += 1;
+        report.errors.push({ path: relative(record.canonicalRoot, path), error: error instanceof Error ? error.message : String(error) });
+      }
+    }
+  }
+  for (const root of ['.ai/harness/controller/worklog.jsonl', '.ai/harness/worklog.jsonl']) {
+    const path = join(record.canonicalRoot, root);
+    if (!existsSync(path)) continue;
+    report.scanned += 1;
+    try {
+      if (migrateJsonl(path, record)) {
+        report.updated += 1;
+        report.files.push(root);
+      }
+    } catch (error) {
+      report.unresolved += 1;
+      report.errors.push({ path: root, error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+  return report;
+}

--- a/src/cli/repositories/identity.ts
+++ b/src/cli/repositories/identity.ts
@@ -1,0 +1,64 @@
+import { createHash, randomUUID } from 'crypto';
+import { basename } from 'path';
+
+function digest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export function normalizeRemoteUrl(input: string | undefined): string | undefined {
+  const raw = input?.trim();
+  if (!raw) return undefined;
+
+  const scpLike = /^(?:([^@\s]+)@)?([^:/\s]+):(.+)$/.exec(raw);
+  const expanded = scpLike && !raw.includes('://')
+    ? `ssh://${scpLike[1] ? `${scpLike[1]}@` : ''}${scpLike[2]}/${scpLike[3]}`
+    : raw;
+
+  try {
+    const url = new URL(expanded);
+    const host = url.hostname.toLowerCase();
+    const port = url.port ? `:${url.port}` : '';
+    const path = decodeURIComponent(url.pathname)
+      .replace(/\\/g, '/')
+      .replace(/\/+$/, '')
+      .replace(/\.git$/i, '')
+      .replace(/^\/+/, '')
+      .toLowerCase();
+    if (!host || !path) return undefined;
+    return `${host}${port}/${path}`;
+  } catch (_error) {
+    return raw
+      .replace(/\\/g, '/')
+      .replace(/\/+$/, '')
+      .replace(/\.git$/i, '')
+      .toLowerCase();
+  }
+}
+
+export function stableRemoteRepoId(canonicalRemote: string): string {
+  return `repo_${digest(`remote\0${canonicalRemote}`).slice(0, 24)}`;
+}
+
+export function newLocalRepoId(): string {
+  return `repo_local_${randomUUID().replace(/-/g, '')}`;
+}
+
+export function stableCheckoutId(repoId: string, canonicalRoot: string): string {
+  return `checkout_${digest(`${repoId}\0${canonicalRoot}`).slice(0, 24)}`;
+}
+
+export function stableWorktreeId(repoId: string, canonicalRoot: string): string {
+  return `worktree_${digest(`${repoId}\0${canonicalRoot}`).slice(0, 24)}`;
+}
+
+export function parseGitHubRemote(canonicalRemote: string | undefined): { owner: string; repo: string } | undefined {
+  if (!canonicalRemote) return undefined;
+  const match = /^github\.com\/([^/]+)\/([^/]+)$/i.exec(canonicalRemote);
+  if (!match) return undefined;
+  return { owner: match[1], repo: match[2] };
+}
+
+export function inferDisplayName(root: string, canonicalRemote?: string): string {
+  const remoteName = canonicalRemote?.split('/').at(-1)?.trim();
+  return remoteName || basename(root) || 'repository';
+}

--- a/src/cli/repositories/registry.ts
+++ b/src/cli/repositories/registry.ts
@@ -1,0 +1,404 @@
+import { spawnSync } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, join, resolve } from 'path';
+import { ensureControllerHome, ensureRepositoryControllerLayout, resolveControllerHome } from './controller-home';
+import {
+  inferDisplayName,
+  newLocalRepoId,
+  normalizeRemoteUrl,
+  parseGitHubRemote,
+  stableCheckoutId,
+  stableRemoteRepoId,
+} from './identity';
+import type {
+  RepositoryCheckout,
+  RepositoryRecord,
+  RepositoryRegistry,
+  RepositoryStateStorageStrategy,
+  RepositorySummary,
+  RepositoryType,
+  RepositoryValidation,
+} from './types';
+
+const REGISTRY_FILE = 'repositories.json';
+const FOCUS_FILE = 'focus.json';
+const LOCAL_CONFIG = '.ai/harness/repository.json';
+
+interface RegisterRepositoryInput {
+  path: string;
+  controllerHome?: string;
+  displayName?: string;
+  remoteUrl?: string;
+  defaultBranch?: string;
+  repositoryType?: RepositoryType;
+  enabled?: boolean;
+  stateStorageStrategy?: RepositoryStateStorageStrategy;
+}
+
+interface UpdateRepositoryInput {
+  displayName?: string;
+  enabled?: boolean;
+  defaultBranch?: string;
+  stateStorageStrategy?: RepositoryStateStorageStrategy;
+  github?: RepositoryRecord['github'];
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function git(root: string, args: string[]): string | undefined {
+  const result = spawnSync('git', ['-C', root, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 10_000,
+  });
+  return result.status === 0 && result.stdout.trim() ? result.stdout.trim() : undefined;
+}
+
+function registryPath(controllerHome?: string): string {
+  return join(resolveControllerHome(controllerHome), REGISTRY_FILE);
+}
+
+function focusPath(controllerHome?: string): string {
+  return join(resolveControllerHome(controllerHome), FOCUS_FILE);
+}
+
+function atomicJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const temp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(temp, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  renameSync(temp, path);
+}
+
+function defaultRegistry(): RepositoryRegistry {
+  return { schemaVersion: 1, repositories: [], updatedAt: now() };
+}
+
+export function loadRepositoryRegistry(controllerHome?: string): RepositoryRegistry {
+  const path = registryPath(controllerHome);
+  if (!existsSync(path)) return defaultRegistry();
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<RepositoryRegistry>;
+    return {
+      schemaVersion: 1,
+      repositories: Array.isArray(parsed.repositories) ? parsed.repositories : [],
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : now(),
+    };
+  } catch (error) {
+    throw new Error(`repository registry is unreadable: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export function saveRepositoryRegistry(registry: RepositoryRegistry, controllerHome?: string): RepositoryRegistry {
+  const home = ensureControllerHome(controllerHome);
+  const next = { ...registry, schemaVersion: 1 as const, updatedAt: now() };
+  atomicJson(join(home, REGISTRY_FILE), next);
+  return next;
+}
+
+function resolveGitRoot(inputPath: string): string {
+  const candidate = resolve(inputPath);
+  if (!existsSync(candidate)) throw new Error(`repository path does not exist: ${candidate}`);
+  const topLevel = git(candidate, ['rev-parse', '--show-toplevel']);
+  if (!topLevel) throw new Error(`path is not a Git repository: ${candidate}`);
+  return realpathSync(topLevel);
+}
+
+function readLocalIdentity(canonicalRoot: string): { repoId?: string } {
+  const path = join(canonicalRoot, LOCAL_CONFIG);
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { repoId?: unknown };
+    return typeof parsed.repoId === 'string' && parsed.repoId.trim()
+      ? { repoId: parsed.repoId.trim() }
+      : {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function writeLocalIdentity(record: RepositoryRecord): void {
+  const path = join(record.canonicalRoot, LOCAL_CONFIG);
+  atomicJson(path, {
+    schemaVersion: 1,
+    repoId: record.repoId,
+    checkoutId: record.activeCheckoutId,
+    stateStorageStrategy: record.stateStorageStrategy,
+  });
+}
+
+function repositoryType(root: string, remoteUrl: string | undefined): RepositoryType {
+  const bare = git(root, ['rev-parse', '--is-bare-repository']);
+  if (bare === 'true') return 'bare';
+  return remoteUrl ? 'git' : 'local-git';
+}
+
+function defaultBranch(root: string): string | undefined {
+  const originHead = git(root, ['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD']);
+  if (originHead?.startsWith('origin/')) return originHead.slice('origin/'.length);
+  const current = git(root, ['branch', '--show-current']);
+  return current || undefined;
+}
+
+function activeCheckout(record: RepositoryRecord): RepositoryCheckout {
+  return record.checkouts.find((checkout) => checkout.checkoutId === record.activeCheckoutId)
+    ?? record.checkouts[0]
+    ?? {
+      checkoutId: record.activeCheckoutId,
+      localRoot: record.localRoot,
+      canonicalRoot: record.canonicalRoot,
+      worktree: false,
+      branch: null,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+      lastSeenAt: record.lastSeenAt,
+    };
+}
+
+export function repositorySummary(record: RepositoryRecord): RepositorySummary {
+  const checkout = activeCheckout(record);
+  return {
+    repoId: record.repoId,
+    displayName: record.displayName,
+    enabled: record.enabled,
+    localRoot: checkout.localRoot,
+    canonicalRoot: checkout.canonicalRoot,
+    checkoutId: checkout.checkoutId,
+    remoteUrl: record.remoteUrl,
+    github: record.github,
+    defaultBranch: record.defaultBranch,
+    repositoryType: record.repositoryType,
+    lastSeenAt: record.lastSeenAt,
+    removedAt: record.removedAt,
+  };
+}
+
+export function listRepositories(controllerHome?: string, options: { includeRemoved?: boolean } = {}): RepositoryRecord[] {
+  return loadRepositoryRegistry(controllerHome).repositories
+    .filter((record) => options.includeRemoved === true || !record.removedAt)
+    .sort((a, b) => a.displayName.localeCompare(b.displayName) || a.repoId.localeCompare(b.repoId));
+}
+
+export function getRepository(repoId: string, controllerHome?: string, options: { includeRemoved?: boolean } = {}): RepositoryRecord {
+  const record = loadRepositoryRegistry(controllerHome).repositories.find((candidate) => candidate.repoId === repoId);
+  if (!record || (record.removedAt && options.includeRemoved !== true)) {
+    throw new Error(`repository not found: ${repoId}`);
+  }
+  return record;
+}
+
+export function selectRepositoryCheckout(record: RepositoryRecord, checkoutId?: string): RepositoryRecord {
+  if (!checkoutId?.trim()) return record;
+  const checkout = record.checkouts.find((candidate) => candidate.checkoutId === checkoutId.trim());
+  if (!checkout) throw new Error(`checkout not found for ${record.repoId}: ${checkoutId}`);
+  return {
+    ...record,
+    localRoot: checkout.localRoot,
+    canonicalRoot: checkout.canonicalRoot,
+    activeCheckoutId: checkout.checkoutId,
+  };
+}
+
+export function registerRepository(input: RegisterRepositoryInput): RepositoryRecord {
+  const home = ensureControllerHome(input.controllerHome);
+  const canonicalRoot = resolveGitRoot(input.path);
+  const rawRemote = input.remoteUrl?.trim() || git(canonicalRoot, ['config', '--get', 'remote.origin.url']);
+  const canonicalRemote = normalizeRemoteUrl(rawRemote);
+  const localIdentity = readLocalIdentity(canonicalRoot);
+  const repoId = canonicalRemote ? stableRemoteRepoId(canonicalRemote) : localIdentity.repoId || newLocalRepoId();
+  const checkoutId = stableCheckoutId(repoId, canonicalRoot);
+  const timestamp = now();
+  const registry = loadRepositoryRegistry(home);
+  const existing = registry.repositories.find((record) => record.repoId === repoId);
+  const checkout: RepositoryCheckout = {
+    checkoutId,
+    localRoot: canonicalRoot,
+    canonicalRoot,
+    worktree: Boolean(git(canonicalRoot, ['rev-parse', '--git-common-dir']) && git(canonicalRoot, ['rev-parse', '--git-dir']) !== git(canonicalRoot, ['rev-parse', '--git-common-dir'])),
+    branch: git(canonicalRoot, ['branch', '--show-current']) ?? null,
+    createdAt: existing?.checkouts.find((value) => value.checkoutId === checkoutId)?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+    lastSeenAt: timestamp,
+  };
+  const github = parseGitHubRemote(canonicalRemote);
+  const record: RepositoryRecord = {
+    schemaVersion: 1,
+    repoId,
+    displayName: input.displayName?.trim() || existing?.displayName || inferDisplayName(canonicalRoot, canonicalRemote),
+    localRoot: canonicalRoot,
+    canonicalRoot,
+    activeCheckoutId: checkoutId,
+    checkouts: [
+      ...(existing?.checkouts.filter((value) => value.checkoutId !== checkoutId) ?? []),
+      checkout,
+    ],
+    remoteUrl: rawRemote,
+    canonicalRemote,
+    github: existing?.github ?? (github ? { ...github, authenticationCapability: 'unknown' } : undefined),
+    defaultBranch: input.defaultBranch?.trim() || existing?.defaultBranch || defaultBranch(canonicalRoot),
+    repositoryType: input.repositoryType ?? existing?.repositoryType ?? repositoryType(canonicalRoot, rawRemote),
+    enabled: input.enabled ?? existing?.enabled ?? true,
+    createdAt: existing?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+    lastSeenAt: timestamp,
+    configurationPath: join(canonicalRoot, LOCAL_CONFIG),
+    stateStorageStrategy: input.stateStorageStrategy ?? existing?.stateStorageStrategy ?? 'hybrid',
+    disabledAt: input.enabled === true ? undefined : existing?.disabledAt,
+    removedAt: undefined,
+  };
+  registry.repositories = [
+    ...registry.repositories.filter((candidate) => candidate.repoId !== repoId),
+    record,
+  ];
+  saveRepositoryRegistry(registry, home);
+  ensureRepositoryControllerLayout(home, repoId);
+  writeLocalIdentity(record);
+  return record;
+}
+
+export function updateRepository(repoId: string, patch: UpdateRepositoryInput, controllerHome?: string): RepositoryRecord {
+  const registry = loadRepositoryRegistry(controllerHome);
+  const index = registry.repositories.findIndex((record) => record.repoId === repoId);
+  if (index < 0) throw new Error(`repository not found: ${repoId}`);
+  const previous = registry.repositories[index];
+  const enabled = patch.enabled ?? previous.enabled;
+  const next: RepositoryRecord = {
+    ...previous,
+    ...patch,
+    displayName: patch.displayName?.trim() || previous.displayName,
+    defaultBranch: patch.defaultBranch?.trim() || previous.defaultBranch,
+    enabled,
+    disabledAt: enabled ? undefined : previous.disabledAt ?? now(),
+    removedAt: enabled ? undefined : previous.removedAt,
+    updatedAt: now(),
+  };
+  registry.repositories[index] = next;
+  saveRepositoryRegistry(registry, controllerHome);
+  writeLocalIdentity(next);
+  return next;
+}
+
+export function disableRepository(repoId: string, controllerHome?: string): RepositoryRecord {
+  return updateRepository(repoId, { enabled: false }, controllerHome);
+}
+
+export function removeRepository(repoId: string, controllerHome?: string): RepositoryRecord {
+  const registry = loadRepositoryRegistry(controllerHome);
+  const index = registry.repositories.findIndex((record) => record.repoId === repoId);
+  if (index < 0) throw new Error(`repository not found: ${repoId}`);
+  const timestamp = now();
+  registry.repositories[index] = {
+    ...registry.repositories[index],
+    enabled: false,
+    disabledAt: registry.repositories[index].disabledAt ?? timestamp,
+    removedAt: timestamp,
+    updatedAt: timestamp,
+  };
+  saveRepositoryRegistry(registry, controllerHome);
+  return registry.repositories[index];
+}
+
+export function purgeRepository(repoId: string, controllerHome?: string): void {
+  const home = resolveControllerHome(controllerHome);
+  const registry = loadRepositoryRegistry(home);
+  registry.repositories = registry.repositories.filter((record) => record.repoId !== repoId);
+  saveRepositoryRegistry(registry, home);
+  rmSync(join(home, 'repositories', repoId), { recursive: true, force: true });
+}
+
+export function validateRepository(repoId: string, controllerHome?: string): RepositoryValidation {
+  const record = getRepository(repoId, controllerHome, { includeRemoved: true });
+  const checkout = activeCheckout(record);
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const rootExists = existsSync(checkout.canonicalRoot);
+  const canonicalRoot = rootExists ? realpathSync(checkout.canonicalRoot) : checkout.canonicalRoot;
+  const gitRepository = rootExists && Boolean(git(canonicalRoot, ['rev-parse', '--show-toplevel']));
+  const remoteUrl = gitRepository ? git(canonicalRoot, ['config', '--get', 'remote.origin.url']) : undefined;
+  const canonicalRemote = normalizeRemoteUrl(remoteUrl);
+  const identityMatches = record.canonicalRemote
+    ? canonicalRemote === record.canonicalRemote
+    : rootExists && canonicalRoot === checkout.canonicalRoot;
+  if (!rootExists) errors.push('checkout root does not exist');
+  if (rootExists && !gitRepository) errors.push('checkout root is no longer a Git repository');
+  if (gitRepository && !identityMatches) errors.push('repository identity does not match the registry record');
+  if (!record.enabled) warnings.push('repository is disabled');
+  if (record.removedAt) warnings.push('repository was removed and is retained for audit only');
+  return {
+    repoId,
+    checkoutId: checkout.checkoutId,
+    ok: errors.length === 0,
+    rootExists,
+    gitRepository,
+    identityMatches,
+    canonicalRoot,
+    canonicalRemote,
+    errors,
+    warnings,
+    checkedAt: now(),
+  };
+}
+
+export function refreshRepository(repoId: string, controllerHome?: string): RepositoryRecord {
+  const record = getRepository(repoId, controllerHome, { includeRemoved: true });
+  const checkout = activeCheckout(record);
+  return registerRepository({
+    path: checkout.canonicalRoot,
+    controllerHome,
+    displayName: record.displayName,
+    defaultBranch: defaultBranch(checkout.canonicalRoot) ?? record.defaultBranch,
+    repositoryType: record.repositoryType,
+    enabled: record.enabled,
+    stateStorageStrategy: record.stateStorageStrategy,
+  });
+}
+
+export function focusRepository(repoId: string | undefined, controllerHome?: string): { repoId?: string; updatedAt: string } {
+  const home = ensureControllerHome(controllerHome);
+  if (repoId) getRepository(repoId, home);
+  const value = { repoId, updatedAt: now() };
+  atomicJson(focusPath(home), value);
+  return value;
+}
+
+export function getRepositoryFocus(controllerHome?: string): { repoId?: string; updatedAt?: string } {
+  const path = focusPath(controllerHome);
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as { repoId?: string; updatedAt?: string };
+  } catch (_error) {
+    return {};
+  }
+}
+
+export function resolveRepositorySelection(input: {
+  repoId?: string;
+  checkoutId?: string;
+  explicitPath?: string;
+  controllerHome?: string;
+  allowSoleRepository?: boolean;
+}): RepositoryRecord {
+  if (input.repoId?.trim()) {
+    const record = getRepository(input.repoId.trim(), input.controllerHome);
+    if (!record.enabled) throw new Error(`repository is disabled: ${record.repoId}`);
+    return selectRepositoryCheckout(record, input.checkoutId);
+  }
+  if (input.explicitPath?.trim()) {
+    return selectRepositoryCheckout(registerRepository({ path: input.explicitPath, controllerHome: input.controllerHome }), input.checkoutId);
+  }
+  const enabled = listRepositories(input.controllerHome).filter((record) => record.enabled);
+  if (input.allowSoleRepository !== false && enabled.length === 1) return selectRepositoryCheckout(enabled[0], input.checkoutId);
+  if (enabled.length === 0) {
+    throw new Error('REPOSITORY_REQUIRED: no enabled repository is registered; pass repoId or register a repository');
+  }
+  throw new Error(`REPOSITORY_AMBIGUOUS: ${enabled.length} enabled repositories are registered; pass repoId explicitly`);
+}

--- a/src/cli/repositories/types.ts
+++ b/src/cli/repositories/types.ts
@@ -1,0 +1,92 @@
+export type RepositoryType = 'git' | 'bare' | 'local-git' | 'unknown';
+export type RepositoryStateStorageStrategy = 'controller-home' | 'repository-local' | 'hybrid';
+
+export interface GitHubRepositoryMapping {
+  owner: string;
+  repo: string;
+  projectOwner?: string;
+  projectNumber?: number;
+  labels?: string[];
+  issueSyncEnabled?: boolean;
+  cloudAgentSupported?: boolean;
+  authenticationCapability?: 'unknown' | 'available' | 'unavailable';
+}
+
+export interface RepositoryCheckout {
+  checkoutId: string;
+  localRoot: string;
+  canonicalRoot: string;
+  worktree: boolean;
+  branch: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastSeenAt: string;
+}
+
+export interface RepositoryRecord {
+  schemaVersion: 1;
+  repoId: string;
+  displayName: string;
+  localRoot: string;
+  canonicalRoot: string;
+  activeCheckoutId: string;
+  checkouts: RepositoryCheckout[];
+  remoteUrl?: string;
+  canonicalRemote?: string;
+  github?: GitHubRepositoryMapping;
+  defaultBranch?: string;
+  repositoryType: RepositoryType;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastSeenAt: string;
+  configurationPath: string;
+  stateStorageStrategy: RepositoryStateStorageStrategy;
+  disabledAt?: string;
+  removedAt?: string;
+}
+
+export interface RepositoryRegistry {
+  schemaVersion: 1;
+  repositories: RepositoryRecord[];
+  updatedAt: string;
+}
+
+export interface RepositorySummary {
+  repoId: string;
+  displayName: string;
+  enabled: boolean;
+  localRoot: string;
+  canonicalRoot: string;
+  checkoutId: string;
+  remoteUrl?: string;
+  github?: GitHubRepositoryMapping;
+  defaultBranch?: string;
+  repositoryType: RepositoryType;
+  lastSeenAt: string;
+  removedAt?: string;
+}
+
+export interface RepositoryValidation {
+  repoId: string;
+  checkoutId: string;
+  ok: boolean;
+  rootExists: boolean;
+  gitRepository: boolean;
+  identityMatches: boolean;
+  canonicalRoot: string;
+  canonicalRemote?: string;
+  errors: string[];
+  warnings: string[];
+  checkedAt: string;
+}
+
+export interface EntityMigrationReport {
+  repoId: string;
+  checkoutId: string;
+  scanned: number;
+  updated: number;
+  unresolved: number;
+  files: string[];
+  errors: Array<{ path: string; error: string }>;
+}

--- a/src/cli/v81-entry.ts
+++ b/src/cli/v81-entry.ts
@@ -1,0 +1,29 @@
+import { buildProgram } from './index';
+import { buildRepositoryCommand } from './commands/repository';
+import { CLI_VERSION } from './commands/status';
+
+export function buildV81Program() {
+  const program = buildProgram();
+  program.addCommand(buildRepositoryCommand());
+  return program;
+}
+
+export async function runV81Cli(argv: string[] = process.argv): Promise<void> {
+  const args = argv.slice(2);
+  if (args.length === 1 && (args[0] === '--version' || args[0] === '-V')) {
+    console.log(CLI_VERSION);
+    return;
+  }
+  await buildV81Program().parseAsync(argv);
+}
+
+if (import.meta.main) {
+  try {
+    await runV81Cli(process.argv);
+  } catch (error) {
+    const value = error as { exitCode?: number; message?: string };
+    if (typeof value.exitCode === 'number') process.exit(value.exitCode);
+    if (value.message) console.error(value.message);
+    process.exit(1);
+  }
+}

--- a/tests/cli/multi-repository-routing-v81.test.ts
+++ b/tests/cli/multi-repository-routing-v81.test.ts
@@ -38,7 +38,7 @@ describe('v8.1 MCP repository routing', () => {
         path: 'cross-repo-link.txt',
       });
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('symlink escapes repository root');
+      expect(result.content[0].text).toContain('path escapes repository root');
     } finally {
       fixture.cleanup();
     }

--- a/tests/cli/multi-repository-routing-v81.test.ts
+++ b/tests/cli/multi-repository-routing-v81.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { symlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { callMultiRepositoryTool, createMcpToolContext } from '../../src/cli/mcp/server';
+import { repositoryFixture } from './repository-v81-fixture';
+
+describe('v8.1 MCP repository routing', () => {
+  test('routes each request by repoId and rejects ambiguous calls', async () => {
+    const fixture = repositoryFixture();
+    try {
+      const ctx = createMcpToolContext({ controllerHome: fixture.controllerHome, profile: 'controller' });
+      const ambiguous = await callMultiRepositoryTool(ctx, 'project_snapshot', {});
+      expect(ambiguous.isError).toBe(true);
+      expect(ambiguous.content[0].text).toContain('REPOSITORY_AMBIGUOUS');
+
+      const statusA = await callMultiRepositoryTool(ctx, 'harness_status', { repo_id: fixture.repoA.repoId });
+      const statusB = await callMultiRepositoryTool(ctx, 'harness_status', { repo_id: fixture.repoB.repoId });
+      expect((statusA.structuredContent as { repoId: string }).repoId).toBe(fixture.repoA.repoId);
+      expect((statusB.structuredContent as { repoId: string }).repoId).toBe(fixture.repoB.repoId);
+      expect((statusA.structuredContent as { repoRoot: string }).repoRoot).toBe(fixture.repoA.canonicalRoot);
+      expect((statusB.structuredContent as { repoRoot: string }).repoRoot).toBe(fixture.repoB.canonicalRoot);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('rejects a symlink that resolves into a different repository', async () => {
+    const fixture = repositoryFixture();
+    try {
+      writeFileSync(join(fixture.repoB.canonicalRoot, 'outside.txt'), 'outside repository\n', 'utf-8');
+      symlinkSync(
+        join(fixture.repoB.canonicalRoot, 'outside.txt'),
+        join(fixture.repoA.canonicalRoot, 'cross-repo-link.txt'),
+      );
+      const ctx = createMcpToolContext({ controllerHome: fixture.controllerHome, profile: 'controller' });
+      const result = await callMultiRepositoryTool(ctx, 'read_repository_file', {
+        repo_id: fixture.repoA.repoId,
+        path: 'cross-repo-link.txt',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('symlink escapes repository root');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/tests/cli/repository-migration-v81.test.ts
+++ b/tests/cli/repository-migration-v81.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { bindRepositoryEntities } from '../../src/cli/repositories/entity-migration';
+import { repositoryFixture } from './repository-v81-fixture';
+
+describe('v8.1 repository ownership migration', () => {
+  test('binds legacy durable entities to the owning repository', () => {
+    const fixture = repositoryFixture();
+    try {
+      const repo = fixture.repoA;
+      const issuePath = join(repo.canonicalRoot, 'tasks', 'issues', 'ISS-1-example.issue.json');
+      writeFileSync(issuePath, JSON.stringify({
+        schemaVersion: 5,
+        id: 'ISS-1',
+        title: 'Example',
+        tasks: [{ id: 'T1', verification: { checkResults: [] } }],
+      }), 'utf-8');
+      const jobRoot = join(repo.canonicalRoot, '.ai', 'harness', 'jobs', 'RUN-1');
+      mkdirSync(jobRoot, { recursive: true });
+      writeFileSync(join(jobRoot, 'meta.json'), JSON.stringify({
+        schemaVersion: 2,
+        runId: 'RUN-1',
+        issueId: 'ISS-1',
+        taskId: 'T1',
+        repoRoot: repo.canonicalRoot,
+        worktree: repo.canonicalRoot,
+      }), 'utf-8');
+      const editRoot = join(repo.canonicalRoot, '.ai', 'harness', 'edit-sessions', 'EDIT-1');
+      mkdirSync(editRoot, { recursive: true });
+      writeFileSync(join(editRoot, 'session.json'), JSON.stringify({ sessionId: 'EDIT-1' }), 'utf-8');
+      writeFileSync(join(repo.canonicalRoot, '.ai', 'harness', 'worklog.jsonl'), `${JSON.stringify({ action: 'legacy' })}\n`, 'utf-8');
+
+      const report = bindRepositoryEntities(repo);
+      expect(report.unresolved).toBe(0);
+      expect(report.updated).toBe(4);
+      const issue = JSON.parse(readFileSync(issuePath, 'utf-8'));
+      expect(issue.repoId).toBe(repo.repoId);
+      expect(issue.tasks[0].repoId).toBe(repo.repoId);
+      expect(issue.tasks[0].verification.repoId).toBe(repo.repoId);
+      const run = JSON.parse(readFileSync(join(jobRoot, 'meta.json'), 'utf-8'));
+      expect(run.repoId).toBe(repo.repoId);
+      expect(run.checkoutId).toBe(repo.activeCheckoutId);
+      expect(run.executionRoot).toBe(repo.canonicalRoot);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('retains conflicting ownership as unresolved instead of rebinding', () => {
+    const fixture = repositoryFixture();
+    try {
+      const issuePath = join(fixture.repoA.canonicalRoot, 'tasks', 'issues', 'ISS-conflict.issue.json');
+      writeFileSync(issuePath, JSON.stringify({
+        schemaVersion: 5,
+        repoId: fixture.repoB.repoId,
+        id: 'ISS-conflict',
+        title: 'Conflict',
+        tasks: [],
+      }), 'utf-8');
+      const report = bindRepositoryEntities(fixture.repoA);
+      expect(report.unresolved).toBe(1);
+      expect(JSON.parse(readFileSync(issuePath, 'utf-8')).repoId).toBe(fixture.repoB.repoId);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/tests/cli/repository-registry-v81.test.ts
+++ b/tests/cli/repository-registry-v81.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  normalizeRemoteUrl,
+  stableCheckoutId,
+  stableRemoteRepoId,
+} from '../../src/cli/repositories/identity';
+import {
+  listRepositories,
+  resolveRepositorySelection,
+} from '../../src/cli/repositories/registry';
+import { repositoryFixture } from './repository-v81-fixture';
+
+describe('v8.1 repository identity and selection', () => {
+  test('normalizes SSH and HTTPS forms to one stable repository identity', () => {
+    const ssh = normalizeRemoteUrl('git@github.com:Example/Same.git');
+    const https = normalizeRemoteUrl('https://GITHUB.com/example/same.git');
+    expect(ssh).toBe('github.com/example/same');
+    expect(https).toBe(ssh);
+    expect(stableRemoteRepoId(ssh!)).toBe(stableRemoteRepoId(https!));
+  });
+
+  test('keeps repository and checkout identities separate', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repo-harness-v81-checkouts-'));
+    try {
+      const repoId = stableRemoteRepoId('github.com/example/same');
+      expect(stableCheckoutId(repoId, join(root, 'one')))
+        .not.toBe(stableCheckoutId(repoId, join(root, 'two')));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects an implicit selection when two repositories are enabled', () => {
+    const fixture = repositoryFixture();
+    try {
+      expect(listRepositories(fixture.controllerHome)).toHaveLength(2);
+      expect(() => resolveRepositorySelection({ controllerHome: fixture.controllerHome }))
+        .toThrow('REPOSITORY_AMBIGUOUS');
+      expect(resolveRepositorySelection({
+        controllerHome: fixture.controllerHome,
+        repoId: fixture.repoB.repoId,
+      }).repoId).toBe(fixture.repoB.repoId);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/tests/cli/repository-v81-fixture.ts
+++ b/tests/cli/repository-v81-fixture.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { stableCheckoutId } from '../../src/cli/repositories/identity';
+import type { RepositoryRecord } from '../../src/cli/repositories/types';
+
+export interface RepositoryFixture {
+  root: string;
+  controllerHome: string;
+  repoA: RepositoryRecord;
+  repoB: RepositoryRecord;
+  cleanup(): void;
+}
+
+function record(root: string, repoId: string, name: string): RepositoryRecord {
+  const canonicalRoot = join(root, name);
+  const checkoutId = stableCheckoutId(repoId, canonicalRoot);
+  const timestamp = '2026-06-22T00:00:00.000Z';
+  mkdirSync(join(canonicalRoot, 'tasks', 'issues'), { recursive: true });
+  mkdirSync(join(canonicalRoot, '.ai', 'harness'), { recursive: true });
+  writeFileSync(join(canonicalRoot, 'tasks', 'current.md'), `# ${name}\n`, 'utf-8');
+  return {
+    schemaVersion: 1,
+    repoId,
+    displayName: name,
+    localRoot: canonicalRoot,
+    canonicalRoot,
+    activeCheckoutId: checkoutId,
+    checkouts: [{
+      checkoutId,
+      localRoot: canonicalRoot,
+      canonicalRoot,
+      worktree: false,
+      branch: 'main',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      lastSeenAt: timestamp,
+    }],
+    repositoryType: 'local-git',
+    enabled: true,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    lastSeenAt: timestamp,
+    configurationPath: join(canonicalRoot, '.ai', 'harness', 'repository.json'),
+    stateStorageStrategy: 'hybrid',
+  };
+}
+
+export function repositoryFixture(): RepositoryFixture {
+  const root = mkdtempSync(join(tmpdir(), 'repo-harness-v81-'));
+  const controllerHome = join(root, 'controller-home');
+  mkdirSync(controllerHome, { recursive: true });
+  const repoA = record(root, 'repo_a', 'repo-a');
+  const repoB = record(root, 'repo_b', 'repo-b');
+  writeFileSync(join(controllerHome, 'repositories.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    repositories: [repoA, repoB],
+    updatedAt: '2026-06-22T00:00:00.000Z',
+  }, null, 2)}\n`, 'utf-8');
+  return {
+    root,
+    controllerHome,
+    repoA,
+    repoB,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}


### PR DESCRIPTION
## Summary

Implements the first executable v8.1 multi-repository foundation instead of binding one Controller process to its startup working directory.

### Included

- persistent Controller Home and Repository Registry
- stable `repoId` from normalized SSH/HTTPS remote identity
- separate repository and checkout identities, including multiple clones of one remote
- local-only repository identity persisted in repo configuration
- register/list/get/update/refresh/validate/disable/remove/focus repository operations
- soft removal that retains historical Controller state
- MCP `repo_id` / `checkout_id` request routing
- explicit `REPOSITORY_AMBIGUOUS` failure when multiple repositories exist and no repository is supplied
- repository-specific MCP policy and result envelope
- `repoId` fields on Issue, Task, Verification and Run type contracts
- Run checkout/execution-root/worktree metadata contract
- migration for legacy Issue, Task, Verification, Run, Edit Session and Worklog records
- conflict-safe migration: existing foreign ownership is retained and reported unresolved
- regression coverage for remote normalization, identity separation, ambiguous routing, migration, per-request routing and symlink isolation

### CLI

Repository management is available through:

```bash
bun run repo:registry -- register <path>
bun run repo:registry -- list
bun run repo:registry -- inspect <repoId>
bun run repo:registry -- validate <repoId>
bun run repo:registry -- refresh <repoId>
bun run repo:registry -- update <repoId>
bun run repo:registry -- disable <repoId>
bun run repo:registry -- remove <repoId>
bun run repo:registry -- focus [repoId]
```

`focus` is stored only as an interactive preference and is not consulted by execution routing.

### Verification performed before PR

- TypeScript strict compilation of the new registry, migration, routing and regression-test modules
- branch diff review: 16 changed files, no unrelated modifications

## Scope boundary

This PR is a safety-critical foundational slice of #1. It does **not** claim the full Issue is complete yet. Follow-up work is still required for full Workbench multi-repository UX, Controller-Home relocation of every runtime artifact, repository-scoped lock hierarchy, complete concurrent dispatch coverage, and explicit multi-repository umbrella orchestration.

Refs #1