### PR TITLE
fix: guard controller worktree cleanup

### DIFF
--- a/src/cli/agent-jobs/integration.ts
+++ b/src/cli/agent-jobs/integration.ts
@@ -1,5 +1,11 @@
 import { createHash } from "crypto";
-import { existsSync, readFileSync, rmSync, statSync } from "fs";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  statSync,
+} from "fs";
 import { spawnSync } from "child_process";
 import { relative } from "path";
 import {
@@ -14,9 +20,13 @@ import { readTaskRunEvidence } from "../controller/run-evidence";
 import { resolveEffectiveTaskState } from "../controller/task-status-resolver";
 import { resolveMcpPath } from "../mcp/paths";
 import type { McpPolicy } from "../mcp/types";
-import { getAgentJob, markAgentJobIntegrated } from "./job-manager";
+import {
+  getAgentJob,
+  listAgentJobs,
+  markAgentJobIntegrated,
+} from "./job-manager";
 
-function sha256(value: string): string {
+function sha256(value: string | Buffer): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
@@ -78,6 +88,161 @@ function baseContent(
   if (binary(result.stdout))
     throw new Error(`binary file integration is not supported: ${path}`);
   return { exists: true, content: result.stdout.toString("utf-8") };
+}
+
+function branchExists(repoRoot: string, branch: string): boolean {
+  return gitBuffer(repoRoot, [
+    "show-ref",
+    "--verify",
+    "--quiet",
+    `refs/heads/${branch}`,
+  ]).ok;
+}
+
+function worktreePathMatchesRoot(
+  repoRoot: string,
+  worktree: string,
+  path: string,
+): boolean {
+  const workerPath = `${worktree}/${path}`;
+  const rootPath = `${repoRoot}/${path}`;
+  const workerExists = existsSync(workerPath);
+  const rootExists = existsSync(rootPath);
+  if (workerExists !== rootExists) return false;
+  if (!workerExists) return true;
+
+  const workerStat = lstatSync(workerPath);
+  const rootStat = lstatSync(rootPath);
+  if (workerStat.isSymbolicLink() || rootStat.isSymbolicLink()) {
+    return (
+      workerStat.isSymbolicLink() &&
+      rootStat.isSymbolicLink() &&
+      readlinkSync(workerPath) === readlinkSync(rootPath)
+    );
+  }
+  if (!workerStat.isFile() || !rootStat.isFile()) return false;
+  return sha256(readFileSync(workerPath)) === sha256(readFileSync(rootPath));
+}
+
+export interface IntegratedWorktreeCleanupAudit {
+  eligible: boolean;
+  reasons: string[];
+  worktreeExists: boolean;
+  branchExists: boolean;
+  uniqueCommitCount: number | null;
+  changedPaths: string[];
+  mismatchedPaths: string[];
+  conflictingRunIds: string[];
+}
+
+export function inspectIntegratedWorktreeCleanup(
+  repoRoot: string,
+  runId: string,
+): IntegratedWorktreeCleanupAudit {
+  const run = getAgentJob(repoRoot, runId);
+  const reasons: string[] = [];
+  const worktreeExists = existsSync(run.worktree);
+  const hasBranch = Boolean(run.branch && branchExists(repoRoot, run.branch));
+  let uniqueCommitCount: number | null = null;
+  let changes: Array<{ status: string; path: string }> = [];
+  const mismatchedPaths: string[] = [];
+
+  if (run.provider !== "local" || run.executionMode !== "worktree") {
+    reasons.push("Run did not use a local isolated worktree");
+  }
+  if (!run.integratedSessionId) {
+    reasons.push("Run has no integrated edit session");
+  }
+
+  const autoFinalizing =
+    run.status === "running" &&
+    run.autoIntegrate === true &&
+    run.progress?.phase === "finalizing";
+  const cleanupRetry = [
+    "succeeded",
+    "failed",
+    "cancelled",
+    "unknown",
+    "waiting_for_user",
+  ].includes(run.status);
+  if (!autoFinalizing && !cleanupRetry) {
+    reasons.push(`Run is still active in status ${run.status}`);
+  }
+
+  const conflictingRunIds = listAgentJobs(repoRoot, 5000)
+    .filter(
+      (entry) =>
+        entry.runId !== runId &&
+        ["queued", "starting", "running", "waiting_for_user"].includes(
+          entry.status,
+        ) &&
+        ((run.branch && entry.branch === run.branch) ||
+          entry.worktree === run.worktree),
+    )
+    .map((entry) => entry.runId);
+  if (conflictingRunIds.length > 0) {
+    reasons.push(
+      `Worktree or branch is referenced by active Runs: ${conflictingRunIds.join(", ")}`,
+    );
+  }
+
+  if (hasBranch) {
+    if (run.branch) {
+      const unique = gitBuffer(repoRoot, [
+        "rev-list",
+        "--count",
+        `HEAD..${run.branch}`,
+      ]);
+      if (!unique.ok) {
+        reasons.push(
+          `Failed to inspect branch-only commits: ${unique.stderr.trim() || "unknown git error"}`,
+        );
+      } else {
+        uniqueCommitCount = Number(unique.stdout.toString("utf-8").trim());
+        if (!Number.isFinite(uniqueCommitCount)) {
+          uniqueCommitCount = null;
+          reasons.push("Git returned an invalid unique-commit count");
+        } else if (uniqueCommitCount > 0) {
+          reasons.push(
+            `Temporary branch contains ${uniqueCommitCount} commit(s) not reachable from the target checkout HEAD`,
+          );
+        }
+      }
+    }
+  } else {
+    uniqueCommitCount = 0;
+  }
+
+  if (worktreeExists) {
+    try {
+      changes = changedPaths(run.worktree);
+      for (const change of changes) {
+        if (!worktreePathMatchesRoot(repoRoot, run.worktree, change.path)) {
+          mismatchedPaths.push(change.path);
+        }
+      }
+      if (mismatchedPaths.length > 0) {
+        reasons.push(
+          `Worktree changes are not fully reproduced in the target workspace: ${mismatchedPaths.join(", ")}`,
+        );
+      }
+    } catch (error) {
+      reasons.push(
+        `Failed to verify worktree contents: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return {
+    eligible: reasons.length === 0,
+    reasons,
+    worktreeExists,
+    branchExists: hasBranch,
+    uniqueCommitCount,
+    changedPaths: changes.map((entry) => entry.path),
+    mismatchedPaths,
+    conflictingRunIds,
+  };
 }
 
 export function integrateAgentJob(
@@ -230,12 +395,27 @@ export function integrateAgentJob(
 export function cleanupIntegratedWorktree(
   repoRoot: string,
   runId: string,
-): { removed: boolean; branchDeleted: boolean } {
+): {
+  removed: boolean;
+  branchDeleted: boolean;
+  audit: IntegratedWorktreeCleanupAudit;
+} {
   const run = getAgentJob(repoRoot, runId);
-  if (run.provider !== "local" || run.executionMode !== "worktree")
-    return { removed: false, branchDeleted: false };
-  if (!run.integratedSessionId)
-    throw new Error("cannot clean an isolated worktree before integration");
+  if (run.provider !== "local" || run.executionMode !== "worktree") {
+    return {
+      removed: false,
+      branchDeleted: false,
+      audit: inspectIntegratedWorktreeCleanup(repoRoot, runId),
+    };
+  }
+
+  const audit = inspectIntegratedWorktreeCleanup(repoRoot, runId);
+  if (!audit.eligible) {
+    throw new Error(
+      `refusing to clean isolated worktree: ${audit.reasons.join("; ")}`,
+    );
+  }
+
   let removed = !existsSync(run.worktree);
   if (!removed) {
     const remove = gitBuffer(repoRoot, [
@@ -245,27 +425,24 @@ export function cleanupIntegratedWorktree(
       run.worktree,
     ]);
     if (!remove.ok)
-      throw new Error(`failed to remove integrated worktree: ${remove.stderr}`);
+      throw new Error(`failed to remove verified worktree: ${remove.stderr}`);
     removed = !existsSync(run.worktree);
-    if (!removed) {
-      rmSync(run.worktree, { recursive: true, force: true });
-      removed = !existsSync(run.worktree);
-    }
     if (!removed)
       throw new Error(
-        `integrated worktree still exists after cleanup: ${run.worktree}`,
+        `verified worktree still exists after git cleanup: ${run.worktree}`,
       );
   }
-  let branchDeleted = !run.branch;
-  if (run.branch) {
-    const deleted = gitBuffer(repoRoot, ["branch", "-D", run.branch]);
+
+  let branchDeleted = !run.branch || !branchExists(repoRoot, run.branch);
+  if (run.branch && !branchDeleted) {
+    const deleted = gitBuffer(repoRoot, ["branch", "-d", run.branch]);
     if (!deleted.ok && !deleted.stderr.includes("not found"))
       throw new Error(
-        `failed to delete integrated worktree branch: ${deleted.stderr}`,
+        `failed to delete verified worktree branch: ${deleted.stderr}`,
       );
-    branchDeleted = true;
+    branchDeleted = !branchExists(repoRoot, run.branch);
   }
-  return { removed, branchDeleted };
+  return { removed, branchDeleted, audit };
 }
 
 export function taskRunDiff(

--- a/tests/cli/integration-cleanup.test.ts
+++ b/tests/cli/integration-cleanup.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+import {
+  cleanupIntegratedWorktree,
+  inspectIntegratedWorktreeCleanup,
+} from "../../src/cli/agent-jobs/integration";
+import type { AgentJobMeta } from "../../src/cli/agent-jobs/types";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function git(cwd: string, ...args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  }
+  return result.stdout.trim();
+}
+
+function fixture(): {
+  root: string;
+  worktree: string;
+  branch: string;
+  baseRevision: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), "repo-harness-worktree-cleanup-"));
+  roots.push(root);
+  git(root, "init");
+  git(root, "config", "user.email", "test@example.com");
+  git(root, "config", "user.name", "Repo Harness Test");
+  writeFileSync(join(root, "example.txt"), "before\n");
+  git(root, "add", "example.txt");
+  git(root, "commit", "-m", "initial");
+  const baseRevision = git(root, "rev-parse", "HEAD");
+  const worktree = join(root, ".ai/harness/worktrees/test-run");
+  const branch = "controller/iss-test-t1-12345678";
+  mkdirSync(join(root, ".ai/harness/worktrees"), { recursive: true });
+  git(root, "worktree", "add", "-b", branch, worktree, baseRevision);
+  return { root, worktree, branch, baseRevision };
+}
+
+function writeRun(
+  fixtureValue: ReturnType<typeof fixture>,
+  overrides: Partial<AgentJobMeta> = {},
+): string {
+  const runId = overrides.runId ?? "RUN-iss-test-t1-1234567890123-12345678";
+  const dir = join(fixtureValue.root, ".ai/harness/jobs", runId);
+  mkdirSync(dir, { recursive: true });
+  for (const name of ["stdout.log", "stderr.log", "events.jsonl"]) {
+    writeFileSync(join(dir, name), "");
+  }
+  const meta: AgentJobMeta = {
+    schemaVersion: 3,
+    runId,
+    issueId: "ISS-TEST",
+    taskId: "T1",
+    agent: "codex",
+    provider: "local",
+    executionMode: "worktree",
+    status: "succeeded",
+    repoRoot: fixtureValue.root,
+    worktree: fixtureValue.worktree,
+    branch: fixtureValue.branch,
+    baseRevision: fixtureValue.baseRevision,
+    promptPath: `.ai/harness/jobs/${runId}/prompt.md`,
+    stdoutPath: `.ai/harness/jobs/${runId}/stdout.log`,
+    stderrPath: `.ai/harness/jobs/${runId}/stderr.log`,
+    resultPath: `.ai/harness/jobs/${runId}/result.json`,
+    eventsPath: `.ai/harness/jobs/${runId}/events.jsonl`,
+    createdAt: new Date().toISOString(),
+    integratedSessionId: "EDIT-integrated",
+    ...overrides,
+  };
+  writeFileSync(join(dir, "meta.json"), `${JSON.stringify(meta, null, 2)}\n`);
+  return runId;
+}
+
+describe("integrated worktree cleanup", () => {
+  test("removes only a branch whose dirty changes are reproduced in the target workspace", () => {
+    const value = fixture();
+    writeFileSync(join(value.worktree, "example.txt"), "after\n");
+    writeFileSync(join(value.root, "example.txt"), "after\n");
+    const runId = writeRun(value);
+
+    const audit = inspectIntegratedWorktreeCleanup(value.root, runId);
+    expect(audit.eligible).toBe(true);
+    expect(audit.uniqueCommitCount).toBe(0);
+    expect(audit.mismatchedPaths).toEqual([]);
+
+    const result = cleanupIntegratedWorktree(value.root, runId);
+    expect(result.removed).toBe(true);
+    expect(result.branchDeleted).toBe(true);
+    expect(existsSync(value.worktree)).toBe(false);
+    expect(() =>
+      git(value.root, "show-ref", "--verify", `refs/heads/${value.branch}`),
+    ).toThrow();
+  });
+
+  test("preserves a worktree when its final contents were not reproduced", () => {
+    const value = fixture();
+    writeFileSync(join(value.worktree, "example.txt"), "worktree-only\n");
+    const runId = writeRun(value);
+
+    const audit = inspectIntegratedWorktreeCleanup(value.root, runId);
+    expect(audit.eligible).toBe(false);
+    expect(audit.mismatchedPaths).toEqual(["example.txt"]);
+    expect(() => cleanupIntegratedWorktree(value.root, runId)).toThrow(
+      "not fully reproduced",
+    );
+    expect(existsSync(value.worktree)).toBe(true);
+  });
+
+  test("preserves a temporary branch with commits not reachable from target HEAD", () => {
+    const value = fixture();
+    writeFileSync(join(value.worktree, "example.txt"), "committed in worktree\n");
+    git(value.worktree, "add", "example.txt");
+    git(value.worktree, "commit", "-m", "unique worktree commit");
+    writeFileSync(join(value.root, "example.txt"), "committed in worktree\n");
+    const runId = writeRun(value);
+
+    const audit = inspectIntegratedWorktreeCleanup(value.root, runId);
+    expect(audit.eligible).toBe(false);
+    expect(audit.uniqueCommitCount).toBe(1);
+    expect(() => cleanupIntegratedWorktree(value.root, runId)).toThrow(
+      "not reachable from the target checkout HEAD",
+    );
+    expect(existsSync(value.worktree)).toBe(true);
+  });
+
+  test("preserves a worktree referenced by another active Run", () => {
+    const value = fixture();
+    writeFileSync(join(value.worktree, "example.txt"), "after\n");
+    writeFileSync(join(value.root, "example.txt"), "after\n");
+    const runId = writeRun(value);
+    const conflictingRunId = writeRun(value, {
+      runId: "RUN-iss-test-t2-1234567890124-87654321",
+      taskId: "T2",
+      status: "waiting_for_user",
+      integratedSessionId: undefined,
+    });
+
+    const audit = inspectIntegratedWorktreeCleanup(value.root, runId);
+    expect(audit.eligible).toBe(false);
+    expect(audit.conflictingRunIds).toEqual([conflictingRunId]);
+    expect(existsSync(value.worktree)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add a structured safety audit before removing integrated task worktrees
- preserve worktrees and branches when they contain unmatched changes, unique commits, or are referenced by another active Run
- remove the raw filesystem deletion fallback and replace forced branch deletion with `git branch -d`
- add focused tests for safe cleanup and the three preservation guards

## Validation

- compared against current `main`; branch is 2 commits ahead and 0 behind
- Node TypeScript syntax checks passed for the implementation and test file
- full `bun test` / project typecheck are delegated to repository CI because Bun is unavailable in the execution container

## Safety

This PR does not delete any existing user worktree or `controller/iss-*` branch. It only changes the cleanup policy used by future/retried cleanup operations.