### PR TITLE
fix: restore CI contracts and MCP stream cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,5 @@
     "@modelcontextprotocol/sdk": "^1.28.0",
     "commander": "^14.0.3",
     "express": "^5.2.1"
-  },
-  "private": true
+  }
 }

--- a/scripts/check-architecture-sync.sh
+++ b/scripts/check-architecture-sync.sh
@@ -70,34 +70,38 @@ require_architecture_file() {
 require_architecture_text() {
   local file="$1"
   local text="$2"
-  require_architecture_file "$file"
+  if ! require_architecture_file "$file"; then
+    return 1
+  fi
   grep -Fq -- "$text" "$file" || architecture_baseline_fail "$file must contain: $text"
 }
 
 check_runtime_architecture_baseline() {
   local file
-  require_architecture_text "docs/architecture/index.md" "Runtime Authority"
-  require_architecture_text "docs/architecture/index.md" "docs/architecture/current/"
-  require_architecture_text "docs/architecture/current/README.md" "Runtime Authority"
-  require_architecture_text "docs/architecture/current/governance.md" "Runtime Authority"
+  local failed=0
+  require_architecture_text "docs/architecture/index.md" "Runtime Authority" || failed=1
+  require_architecture_text "docs/architecture/index.md" "docs/architecture/current/" || failed=1
+  require_architecture_text "docs/architecture/current/README.md" "Runtime Authority" || failed=1
+  require_architecture_text "docs/architecture/current/governance.md" "Runtime Authority" || failed=1
 
   for file in "${required_current_docs[@]}"; do
-    require_architecture_file "$file"
+    require_architecture_file "$file" || failed=1
   done
 
   for file in "${historical_runtime_docs[@]}"; do
-    require_architecture_text "$file" "Historical Design"
-    require_architecture_text "$file" "Not Runtime Authority"
-    require_architecture_text "$file" "architecture/current/README.md"
+    require_architecture_text "$file" "Historical Design" || failed=1
+    require_architecture_text "$file" "Not Runtime Authority" || failed=1
+    require_architecture_text "$file" "architecture/current/README.md" || failed=1
   done
 
-  require_architecture_text "docs/architecture/current/architecture-invariants.md" "Invariant 2 — Persist Before Execute"
-  require_architecture_text "docs/architecture/current/architecture-invariants.md" "Invariant 4 — Task Is Intent; Run Is Attempt"
-  require_architecture_text "docs/architecture/current/architecture-invariants.md" "Invariant 16 — Evidence Binds to Exact Revision"
-  require_architecture_text "docs/architecture/current/architecture-invariants.md" "Invariant 21 — Scheduled Work Is Bounded"
-  require_architecture_text "docs/architecture/current/implementation-status.md" "## Completion Statement"
-  require_architecture_text "docs/architecture/current/migration-roadmap.md" "## P0"
-  require_architecture_text "docs/architecture/current/migration-roadmap.md" "## P5"
+  require_architecture_text "docs/architecture/current/architecture-invariants.md" "Invariant 2 — Persist Before Execute" || failed=1
+  require_architecture_text "docs/architecture/current/architecture-invariants.md" "Invariant 4 — Task Is Intent; Run Is Attempt" || failed=1
+  require_architecture_text "docs/architecture/current/architecture-invariants.md" "Invariant 16 — Evidence Binds to Exact Revision" || failed=1
+  require_architecture_text "docs/architecture/current/architecture-invariants.md" "Invariant 21 — Scheduled Work Is Bounded" || failed=1
+  require_architecture_text "docs/architecture/current/implementation-status.md" "## Completion Statement" || failed=1
+  require_architecture_text "docs/architecture/current/migration-roadmap.md" "## P0" || failed=1
+  require_architecture_text "docs/architecture/current/migration-roadmap.md" "## P5" || failed=1
+  return "$failed"
 }
 
 while [[ $# -gt 0 ]]; do

--- a/src/cli/mcp/transports/http.ts
+++ b/src/cli/mcp/transports/http.ts
@@ -399,11 +399,21 @@ async function handleMcpGet(req: Request, res: Response, transports: Map<string,
   }
   managed.lastSeenAt = Date.now();
   managed.inFlightGets += 1;
+  let released = false;
+  const releaseStream = (): void => {
+    if (released) return;
+    released = true;
+    managed.inFlightGets = Math.max(0, managed.inFlightGets - 1);
+    managed.lastSeenAt = Date.now();
+  };
+  req.once('aborted', releaseStream);
+  res.once('close', releaseStream);
   try {
     await managed.transport.handleRequest(req, res);
   } finally {
-    managed.inFlightGets -= 1;
-    managed.lastSeenAt = Date.now();
+    req.off('aborted', releaseStream);
+    res.off('close', releaseStream);
+    releaseStream();
   }
 }
 

--- a/tests/architecture-sync.test.ts
+++ b/tests/architecture-sync.test.ts
@@ -21,6 +21,8 @@ const REQUIRED_CURRENT_DOCS = [
   "verification-and-release-gates.md",
   "implementation-status.md",
   "migration-roadmap.md",
+  "runtime-directory-map.md",
+  "operations-runbook.md",
 ];
 
 const HISTORICAL_RUNTIME_DOCS = [
@@ -49,7 +51,7 @@ function installRuntimeArchitectureBaseline(cwd: string): void {
       ].join("\n");
     }
     if (file === "implementation-status.md") {
-      content += "\n## Implementation Gap\n";
+      content += "\n## Completion Statement\n";
     }
     if (file === "migration-roadmap.md") {
       content += "\n## P0\n\n## P1\n\n## P2\n\n## P3\n\n## P4\n\n## P5\n";

--- a/tests/cli/mcp-setup.test.ts
+++ b/tests/cli/mcp-setup.test.ts
@@ -55,7 +55,7 @@ describe("mcp setup", () => {
         oauthFile: ".repo-harness/mcp.oauth.json",
         tokenFile: ".repo-harness/mcp.tokens.json",
       });
-      expect(config.chatgpt.serverName).toBe("repo-harness-controller-v7");
+      expect(config.chatgpt.serverName).toBe("repo-harness-controller-v8");
       expect(config.profile).toBe("controller");
       expect(config.localController).toEqual({
         enabled: true,
@@ -93,7 +93,7 @@ describe("mcp setup", () => {
       );
       expect(doctor.mcp.authConfigured).toBe(true);
       expect(doctor.mcp.devMode.agentRunner).toBe(true);
-      expect(doctor.chatgpt.serverName).toBe("repo-harness-controller-v7");
+      expect(doctor.chatgpt.serverName).toBe("repo-harness-controller-v8");
       expect(doctor.chatgpt.localEndpoint).toBe("http://127.0.0.1:8765/mcp");
       expect(doctor.chatgpt.localController).toBe("http://127.0.0.1:8766/");
       expect(doctor.mcp.localController.enabled).toBe(true);
@@ -127,7 +127,7 @@ describe("mcp setup", () => {
       const config = JSON.parse(
         readFileSync(join(repoRoot, ".repo-harness/mcp.local.json"), "utf-8"),
       );
-      expect(config.chatgpt.serverName).toBe("repo-harness-controller-v7");
+      expect(config.chatgpt.serverName).toBe("repo-harness-controller-v8");
       expect(config.devMode.timeoutMs).toBe(3_600_000);
       expect(config.devMode.maxTimeoutMs).toBe(43_200_000);
     });
@@ -206,7 +206,7 @@ describe("mcp setup", () => {
       expect(doctor.chatgpt.serverName).toBeUndefined();
       expect(doctor.chatgpt.serverNameConfigured).toBe(false);
       expect(doctor.chatgpt.defaultServerName).toBe(
-        "repo-harness-controller-v7",
+        "repo-harness-controller-v8",
       );
       expect(doctor.chatgpt.publicEndpoint).toBe(
         "https://repo-harness-mcp.example.com/mcp",


### PR DESCRIPTION
## Problems
1. Architecture baseline checks could print structural errors and still return success because the function runs inside `if ! function`, where Bash suppresses `errexit` and later successful commands overwrite earlier failures.
2. The architecture test baseline omitted two required documents and the current completion marker.
3. `package.json` retained `private: true` despite the repository's public `repo-harness` 1.x npm release contract.
4. Cancelled MCP HTTP GET/SSE streams remained counted as active until the SDK request promise eventually settled, leaving `activeStreams` stale and contributing to connection lifecycle pressure.

## Fix
- Explicitly aggregate Architecture Sync baseline failures and return non-zero when any structural check fails.
- Stop text checks immediately when their source file is absent.
- Align the architecture fixture with `runtime-directory-map.md`, `operations-runbook.md`, and `## Completion Statement`.
- Remove the stale package-private flag.
- Release `inFlightGets` idempotently on request abort or response close while preserving the MCP session.

## Verification
- Architecture Sync focused suite: passed.
- MCP HTTP transport suite: passed.
- TypeScript typecheck: passed.
- Standard full CI is rerunning on a branch with no Workflow changes.