### PR TITLE
fix: bound controller issue and task detail reads

### DIFF
--- a/src/cli/controller/issue-store.ts
+++ b/src/cli/controller/issue-store.ts
@@ -28,6 +28,9 @@ import { executionScopesConflict, taskExecutionPolicy, verificationEvidencePasse
 
 const ISSUE_ROOT = 'tasks/issues';
 const EPHEMERAL_ISSUE_ROOT = '.ai/harness/ephemeral-issues';
+const ISSUE_SUMMARY_NOTE_LIMIT = 2;
+const ISSUE_SUMMARY_NOTE_CHARS = 280;
+const ISSUE_SUMMARY_RUN_ID_LIMIT = 10;
 
 function slugify(value: string): string {
   return value.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 64) || 'issue';
@@ -211,8 +214,71 @@ export function projectIssueEffectiveView(repoRoot: string, issue: ControllerIss
   };
 }
 
+function summarizeText(value: string, maxChars: number): string {
+  return value.length <= maxChars ? value : `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function summarizeNotes(notes: string[]): string[] {
+  return notes.slice(-ISSUE_SUMMARY_NOTE_LIMIT).map((note) => summarizeText(note, ISSUE_SUMMARY_NOTE_CHARS));
+}
+
+function summarizeVerification(verification?: TaskVerification) {
+  if (!verification) return undefined;
+  return {
+    repoId: verification.repoId,
+    runId: verification.runId,
+    integratedRevision: verification.integratedRevision,
+    reviewedDiffHash: verification.reviewedDiffHash,
+    checkResults: verification.checkResults,
+    acceptanceResults: verification.acceptanceResults.map((result) => ({
+      criterion: result.criterion,
+      ok: result.ok,
+    })),
+    acceptanceResultCount: verification.acceptanceResults.length,
+    commandEvidenceCount: verification.commandEvidence?.length ?? 0,
+    reviewer: verification.reviewer,
+    verifiedAt: verification.verifiedAt,
+    autoCompleted: verification.autoCompleted,
+    detailLevel: 'summary' as const,
+  };
+}
+
+function summarizeEffectiveTaskView(task: ReturnType<typeof projectIssueEffectiveView>['tasks'][number]) {
+  const {
+    notes,
+    runIds,
+    verification,
+    historicalRunOutcomes,
+    ...rest
+  } = task;
+  return {
+    ...rest,
+    notes: summarizeNotes(notes),
+    noteCount: notes.length,
+    runIds: runIds.slice(-ISSUE_SUMMARY_RUN_ID_LIMIT),
+    runIdCount: runIds.length,
+    verification: summarizeVerification(verification),
+    historicalRunOutcomeCount: historicalRunOutcomes.length,
+  };
+}
+
 export function getIssueEffectiveView(repoRoot: string, id: string) {
   return projectIssueEffectiveView(repoRoot, getIssue(repoRoot, id));
+}
+
+export function getIssueReadView(
+  repoRoot: string,
+  id: string,
+  detailLevel: 'summary' | 'full' = 'summary',
+) {
+  const full = getIssueEffectiveView(repoRoot, id);
+  if (detailLevel === 'full') return { ...full, detailLevel };
+  return {
+    ...full,
+    detailLevel,
+    tasks: full.tasks.map(summarizeEffectiveTaskView),
+    next: 'Call get_issue with detail_level=full only when full notes, verification evidence, or run history is required.',
+  };
 }
 
 export function listIssueEffectiveViews(repoRoot: string) {

--- a/src/cli/controller/progress.ts
+++ b/src/cli/controller/progress.ts
@@ -4,7 +4,7 @@ import { getIssue, listIssues } from "./issue-store";
 import { readIssueRunEvidence, readTaskRunEvidence } from "./run-evidence";
 import { loadControllerProjectState } from "./project-state";
 import { taskExecutionPolicy, verificationEvidencePassed } from "./execution-policy";
-import type { ControllerIssue, ControllerTask, TaskStatus } from "./types";
+import type { ControllerIssue, ControllerTask, TaskStatus, TaskVerification } from "./types";
 import { resolveEffectiveTaskState, resolveIssueTaskStates, resolveTaskDependencies } from "./task-status-resolver";
 import {
   listControllerWorklogEvents,
@@ -15,6 +15,9 @@ import {
 const TERMINAL_TASKS = new Set<TaskStatus>(["done", "cancelled", "superseded"]);
 const ACTIVE_RUNS = new Set(["queued", "starting", "running", "waiting_for_user"]);
 const FAILED_RUNS = new Set(["failed", "unknown", "cancelled"]);
+const TASK_PROGRESS_SUMMARY_RUN_LIMIT = 6;
+const TASK_PROGRESS_SUMMARY_TIMELINE_LIMIT = 20;
+const TASK_PROGRESS_SUMMARY_ERROR_CHARS = 280;
 
 export type EvidenceGateState = "pending" | "in_progress" | "passed" | "failed" | "not_required";
 
@@ -130,6 +133,79 @@ export interface ControllerTimelineEvent {
   jobId?: string;
   editSessionId?: string;
   details?: Record<string, unknown>;
+}
+
+function summarizeText(value: string | undefined, maxChars: number): string | undefined {
+  if (!value) return value;
+  return value.length <= maxChars ? value : `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function summarizeVerification(verification?: TaskVerification) {
+  if (!verification) return undefined;
+  return {
+    repoId: verification.repoId,
+    runId: verification.runId,
+    integratedRevision: verification.integratedRevision,
+    reviewedDiffHash: verification.reviewedDiffHash,
+    checkResults: verification.checkResults,
+    acceptanceResults: verification.acceptanceResults.map((result) => ({
+      criterion: result.criterion,
+      ok: result.ok,
+    })),
+    acceptanceResultCount: verification.acceptanceResults.length,
+    commandEvidenceCount: verification.commandEvidence?.length ?? 0,
+    reviewer: verification.reviewer,
+    verifiedAt: verification.verifiedAt,
+    autoCompleted: verification.autoCompleted,
+    detailLevel: "summary" as const,
+  };
+}
+
+function summarizeRun(run: AgentJobMeta) {
+  return {
+    runId: run.runId,
+    issueId: run.issueId,
+    taskId: run.taskId,
+    agent: run.agent,
+    provider: run.provider,
+    executionMode: run.executionMode,
+    status: run.status,
+    exitCode: run.exitCode,
+    error: summarizeText(run.error, TASK_PROGRESS_SUMMARY_ERROR_CHARS),
+    timeoutMs: run.timeoutMs,
+    deadlineAt: run.deadlineAt,
+    lastHeartbeatAt: run.lastHeartbeatAt,
+    progress: run.progress,
+    autoIntegrationError: summarizeText(run.autoIntegrationError, TASK_PROGRESS_SUMMARY_ERROR_CHARS),
+    createdAt: run.createdAt,
+    startedAt: run.startedAt,
+    finishedAt: run.finishedAt,
+    integratedSessionId: run.integratedSessionId,
+    integratedAt: run.integratedAt,
+    timing: run.timing,
+    github: run.github
+      ? {
+          owner: run.github.owner,
+          repo: run.github.repo,
+          taskId: run.github.taskId,
+          state: run.github.state,
+          url: run.github.url,
+          pullRequestUrl: run.github.pullRequestUrl,
+          baseRef: run.github.baseRef,
+          model: run.github.model,
+          createPullRequest: run.github.createPullRequest,
+        }
+      : undefined,
+    detailLevel: "summary" as const,
+  };
+}
+
+function summarizeTimelineEvent(event: ControllerTimelineEvent) {
+  const { details, ...rest } = event;
+  return {
+    ...rest,
+    summary: summarizeText(rest.summary, 120) ?? "",
+  };
 }
 
 function runById(runs: AgentJobMeta[]): Map<string, AgentJobMeta> {
@@ -492,5 +568,52 @@ export function getTaskProgressDetail(repoRoot: string, issueId: string, taskId:
     progress,
     runs,
     timeline: getControllerTimeline(repoRoot, { issueId, taskId, limit: 300 }),
+  };
+}
+
+export function getTaskProgressReadView(
+  repoRoot: string,
+  issueId: string,
+  taskId: string,
+  detailLevel: "summary" | "full" = "summary",
+) {
+  const full = getTaskProgressDetail(repoRoot, issueId, taskId);
+  if (detailLevel === "full") return { ...full, detailLevel };
+
+  const {
+    notes,
+    runIds,
+    verification,
+    effectiveState,
+    ...task
+  } = full.task;
+  const summarizedRuns = full.runs.slice(-TASK_PROGRESS_SUMMARY_RUN_LIMIT).map(summarizeRun);
+  const summarizedTimeline = getControllerTimeline(repoRoot, {
+    issueId,
+    taskId,
+    limit: TASK_PROGRESS_SUMMARY_TIMELINE_LIMIT,
+  }).map(summarizeTimelineEvent);
+
+  return {
+    ...full,
+    detailLevel,
+    task: {
+      ...task,
+      notes: notes.slice(-2).map((note) => summarizeText(note, TASK_PROGRESS_SUMMARY_ERROR_CHARS) ?? ""),
+      noteCount: notes.length,
+      runIds: runIds.slice(-TASK_PROGRESS_SUMMARY_RUN_LIMIT),
+      runIdCount: runIds.length,
+      verification: summarizeVerification(verification),
+      effectiveState: {
+        ...effectiveState,
+        historicalRunOutcomeCount: effectiveState.historicalRunOutcomes.length,
+        historicalRunOutcomes: [],
+      },
+    },
+    runs: summarizedRuns,
+    runCount: full.runs.length,
+    timeline: summarizedTimeline,
+    timelineCount: full.timeline.length,
+    next: "Call get_task_progress_detail with detail_level=full only when full run metadata or the complete timeline is required.",
   };
 }

--- a/src/cli/mcp/legacy-tool-service.ts
+++ b/src/cli/mcp/legacy-tool-service.ts
@@ -41,6 +41,7 @@ import {
   createIssue,
   getIssue,
   getIssueEffectiveView,
+  getIssueReadView,
   inspectIssueReadiness,
   inspectTaskReadiness,
   acceptVerifiedTask,
@@ -65,6 +66,7 @@ import {
   getControllerTimeline,
   getProjectProgress,
   getTaskProgressDetail,
+  getTaskProgressReadView,
 } from "../controller/progress";
 import { exportControllerWorklog, parseWorklogCategory } from "../controller/worklog";
 import { inspectProjectGovernance, reconcileProjectGovernance } from "../controller/governance";
@@ -1746,12 +1748,13 @@ export function buildMcpToolDefinitions(
       {
         name: "get_task_progress_detail",
         description:
-          "Return one Task with effective progress, Run history, Verification evidence, and unified worklog timeline.",
+          "Return one Task with effective progress, bounded Run and timeline summaries by default, and full detail on demand.",
         inputSchema: {
           type: "object",
           properties: {
             issue_id: { type: "string" },
             task_id: { type: "string" },
+            detail_level: { type: "string", enum: ["summary", "full"] },
           },
           required: ["issue_id", "task_id"],
           additionalProperties: false,
@@ -1825,10 +1828,13 @@ export function buildMcpToolDefinitions(
       },
       {
         name: "get_issue",
-        description: "Read one controller issue by ID.",
+        description: "Read one controller issue by ID with bounded task summaries by default and full detail on demand.",
         inputSchema: {
           type: "object",
-          properties: { issue_id: { type: "string" } },
+          properties: {
+            issue_id: { type: "string" },
+            detail_level: { type: "string", enum: ["summary", "full"] },
+          },
           required: ["issue_id"],
           additionalProperties: false,
         },
@@ -3370,10 +3376,11 @@ export async function callMcpTool(
       case "get_task_progress_detail": {
         if (ctx.policy.profile !== "controller")
           return errorResult("TOOL_DISABLED", "get_task_progress_detail requires the controller profile");
-        const result = getTaskProgressDetail(
+        const result = getTaskProgressReadView(
           ctx.repoRoot,
           String(args.issue_id ?? ""),
           String(args.task_id ?? ""),
+          args.detail_level === "full" ? "full" : "summary",
         );
         audit(ctx, name, "ok", args, `tasks/issues/${result.issue.id}`);
         return textResult(result);
@@ -3437,7 +3444,11 @@ export async function callMcpTool(
             "TOOL_DISABLED",
             "get_issue requires the controller profile",
           );
-        const issue = getIssueEffectiveView(ctx.repoRoot, String(args.issue_id ?? ""));
+        const issue = getIssueReadView(
+          ctx.repoRoot,
+          String(args.issue_id ?? ""),
+          args.detail_level === "full" ? "full" : "summary",
+        );
         audit(ctx, name, "ok", args, `tasks/issues/${issue.id}`);
         return textResult(issue);
       }

--- a/tests/cli/mcp-controller.test.ts
+++ b/tests/cli/mcp-controller.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "os";
 import { spawnSync } from "child_process";
 import { join } from "path";
 import { writeJsonAtomic } from "../../src/runtime/shared/json-files";
+import { appendControllerWorklogEvent } from "../../src/cli/controller/worklog";
 import { createExecutionJob, updateExecutionJob } from "../../src/runtime/execution/jobs/store";
 import { callRuntimeTool } from "../../src/runtime/gateway/mcp/runtime-tools";
 import { getMcpPolicy } from "../../src/cli/mcp/policy";
@@ -85,6 +86,95 @@ async function withController<T>(
     else process.env.REPO_HARNESS_CONTROLLER_HOME = previousControllerHome;
     rmSync(repoRoot, { recursive: true, force: true });
     rmSync(controllerHome, { recursive: true, force: true });
+  }
+}
+
+function issueFilePath(
+  repoRoot: string,
+  issue: { id: string; slug: string },
+) {
+  return join(repoRoot, "tasks/issues", `${issue.id}-${issue.slug}.issue.json`);
+}
+
+function seedLargeControllerIssue(
+  repoRoot: string,
+  issue: { id: string; slug: string; tasks: Array<{ id: string }> },
+) {
+  const path = issueFilePath(repoRoot, issue);
+  const stored = JSON.parse(readFileSync(path, "utf-8")) as Record<string, any>;
+  const task = stored.tasks[0];
+  task.notes = Array.from({ length: 24 }, (_, index) =>
+    `note-${index}: ${"controller-summary-payload ".repeat(24)}`,
+  );
+  task.runIds = Array.from({ length: 18 }, (_, index) => `RUN-SUMMARY-${index + 1}`);
+  task.verification = {
+    runId: task.runIds.at(-1),
+    checkResults: Array.from({ length: 4 }, (_, index) => ({
+      checkId: `check-${index + 1}`,
+      ok: true,
+      summary: `summary-${index + 1}`,
+    })),
+    commandEvidence: Array.from({ length: 6 }, (_, index) => ({
+      command: ["bun", "test", `suite-${index + 1}`],
+      ok: true,
+      stdout: "stdout ".repeat(200),
+      stderr: "stderr ".repeat(120),
+    })),
+    acceptanceResults: Array.from({ length: 5 }, (_, index) => ({
+      criterion: `criterion-${index + 1}`,
+      ok: true,
+      evidence: "evidence ".repeat(80),
+    })),
+    reviewer: "summary-fixture",
+    verifiedAt: "2026-06-26T12:00:00.000Z",
+  };
+  writeJsonAtomic(path, stored);
+
+  for (let index = 0; index < task.runIds.length; index += 1) {
+    const runId = task.runIds[index];
+    writeJsonAtomic(join(repoRoot, ".ai/harness/jobs", runId, "meta.json"), {
+      schemaVersion: 3,
+      runId,
+      issueId: stored.id,
+      taskId: task.id,
+      agent: "codex",
+      provider: "local",
+      executionMode: "worktree",
+      status: index === task.runIds.length - 1 ? "succeeded" : "failed",
+      repoRoot,
+      worktree: join(repoRoot, ".ai/harness/worktrees", runId),
+      branch: `codex/${runId.toLowerCase()}`,
+      baseRevision: "abc1234",
+      promptPath: join(repoRoot, ".ai/harness/jobs", runId, "prompt.md"),
+      stdoutPath: join(repoRoot, ".ai/harness/jobs", runId, "stdout.log"),
+      stderrPath: join(repoRoot, ".ai/harness/jobs", runId, "stderr.log"),
+      resultPath: join(repoRoot, ".ai/harness/jobs", runId, "result.json"),
+      eventsPath: join(repoRoot, ".ai/harness/jobs", runId, "events.jsonl"),
+      error: index === task.runIds.length - 1 ? undefined : "failure ".repeat(80),
+      progress: {
+        phase: index === task.runIds.length - 1 ? "completed" : "failed",
+        percent: index === task.runIds.length - 1 ? 100 : 0,
+        currentActivity: `run-${index + 1}`,
+        lastActivityAt: `2026-06-26T12:${String(index).padStart(2, "0")}:00.000Z`,
+        activityCount: 12 + index,
+      },
+      createdAt: `2026-06-26T11:${String(index).padStart(2, "0")}:00.000Z`,
+      startedAt: `2026-06-26T11:${String(index).padStart(2, "0")}:10.000Z`,
+      finishedAt: `2026-06-26T11:${String(index).padStart(2, "0")}:50.000Z`,
+    });
+  }
+
+  for (let index = 0; index < 140; index += 1) {
+    appendControllerWorklogEvent(repoRoot, {
+      at: `2026-06-26T13:${String(Math.floor(index / 2)).padStart(2, "0")}:${index % 2 === 0 ? "00" : "30"}.000Z`,
+      category: "run",
+      action: "run_activity",
+      summary: `timeline-${index + 1}: ${"history ".repeat(20)}`,
+      issueId: stored.id,
+      taskId: task.id,
+      runId: task.runIds[index % task.runIds.length],
+      details: { message: "detail ".repeat(120) },
+    });
   }
 }
 
@@ -219,6 +309,90 @@ describe("MCP controller profile", () => {
       const status = await jsonTool(ctx, "get_github_plugin_status");
       expect(status.value.ready).toBe(false);
       expect(status.value.config.repository).toBe("owner/repository");
+    });
+  });
+
+  test("returns bounded issue summaries by default and keeps full detail opt-in", async () => {
+    await withController(async (repoRoot, ctx) => {
+      const created = await jsonTool(ctx, "create_issue", {
+        title: "Bounded issue summary",
+        summary: "Exercise summary and full issue reads.",
+        tasks: [{
+          title: "Large task",
+          objective: "Seed large controller metadata.",
+          allowed_paths: ["src/**"],
+          checks: ["focused"],
+        }],
+      });
+      seedLargeControllerIssue(repoRoot, created.value);
+
+      const summary = await jsonTool(ctx, "get_issue", {
+        issue_id: created.value.id,
+      });
+      const full = await jsonTool(ctx, "get_issue", {
+        issue_id: created.value.id,
+        detail_level: "full",
+      });
+
+      expect(summary.value.detailLevel).toBe("summary");
+      expect(summary.value.tasks[0].noteCount).toBe(24);
+      expect(summary.value.tasks[0].notes).toHaveLength(2);
+      expect(summary.value.tasks[0].runIdCount).toBe(18);
+      expect(summary.value.tasks[0].runIds).toHaveLength(10);
+      expect(summary.value.tasks[0].verification.commandEvidenceCount).toBe(6);
+      expect(summary.value.tasks[0].verification.commandEvidence).toBeUndefined();
+      expect(summary.value.tasks[0].historicalRunOutcomes).toBeUndefined();
+      expect(full.value.detailLevel).toBe("full");
+      expect(full.value.tasks[0].notes).toHaveLength(24);
+      expect(full.value.tasks[0].runIds).toHaveLength(18);
+      expect(full.value.tasks[0].verification.commandEvidence).toHaveLength(6);
+      expect(Buffer.byteLength(summary.raw.content[0].text)).toBeLessThan(12_000);
+      expect(Buffer.byteLength(full.raw.content[0].text)).toBeGreaterThan(30_000);
+    });
+  });
+
+  test("returns bounded task progress detail by default and keeps full detail opt-in", async () => {
+    await withController(async (repoRoot, ctx) => {
+      const created = await jsonTool(ctx, "create_issue", {
+        title: "Bounded task detail",
+        summary: "Exercise summary and full task detail reads.",
+        tasks: [{
+          title: "Large task detail",
+          objective: "Seed large run history and timeline.",
+          allowed_paths: ["src/**"],
+          checks: ["focused"],
+        }],
+      });
+      seedLargeControllerIssue(repoRoot, created.value);
+
+      const summary = await jsonTool(ctx, "get_task_progress_detail", {
+        issue_id: created.value.id,
+        task_id: "T1",
+      });
+      const full = await jsonTool(ctx, "get_task_progress_detail", {
+        issue_id: created.value.id,
+        task_id: "T1",
+        detail_level: "full",
+      });
+
+      expect(summary.value.detailLevel).toBe("summary");
+      expect(summary.value.runCount).toBe(18);
+      expect(summary.value.runs.length).toBeGreaterThan(0);
+      expect(summary.value.runs.length).toBeLessThanOrEqual(6);
+      expect(summary.value.runs[0].repoRoot).toBeUndefined();
+      expect(summary.value.runs[0].promptPath).toBeUndefined();
+      expect(summary.value.task.noteCount).toBe(24);
+      expect(summary.value.task.runIdCount).toBe(18);
+      expect(summary.value.task.effectiveState.historicalRunOutcomeCount).toBeGreaterThan(0);
+      expect(summary.value.task.effectiveState.historicalRunOutcomes).toHaveLength(0);
+      expect(summary.value.timelineCount).toBeGreaterThan(summary.value.timeline.length);
+      expect(summary.value.timeline.length).toBeLessThanOrEqual(20);
+      expect(full.value.detailLevel).toBe("full");
+      expect(full.value.runs).toHaveLength(18);
+      expect(full.value.timeline.length).toBeGreaterThan(60);
+      expect(full.value.runs[0].repoRoot).toBe(repoRoot);
+      expect(Buffer.byteLength(summary.raw.content[0].text)).toBeLessThan(20_000);
+      expect(Buffer.byteLength(full.raw.content[0].text)).toBeGreaterThan(50_000);
     });
   });
 


### PR DESCRIPTION
## Summary
- add summary/full read views for get_issue and get_task_progress_detail
- bound default task notes, run history, verification evidence, and timeline payloads
- add regression coverage for oversized controller issue/task responses

## Verification
- bun test tests/cli/mcp-controller.test.ts
- bun run check:type
- bash scripts/verify-controller-v8.sh