### PR TITLE
feat: add Request and Full Access repository permissions

### DIFF
--- a/docs/architecture/current/repository-access-modes.md
+++ b/docs/architecture/current/repository-access-modes.md
@@ -1,0 +1,113 @@
+# Repository access modes
+
+repo-harness exposes two user-selectable permission levels for repository work:
+
+- `request` — the default. Read-only work and bounded Direct Control edits may proceed, while elevated local effects ask for approval.
+- `full_access` — permits normal local work inside the selected repository without repeated approval prompts.
+
+The mode is repository-scoped. It is not a machine-wide sandbox bypass.
+
+## Safety boundary
+
+`full_access` automatically permits:
+
+- reading and writing files in the selected repository;
+- repository-scoped local commands;
+- dependency changes;
+- local Git operations;
+- registered checks and verification.
+
+It does **not** automatically permit:
+
+- paths outside the selected repository;
+- external network access;
+- Git push or other remote writes;
+- deployments, publishing, or destructive actions;
+- raw secret, token, private-key, or credential access;
+- bypassing managed controller policy.
+
+Those effects continue to require approval or remain denied by the existing hard policy.
+
+## Storage
+
+The repository default is stored under controller-owned runtime state:
+
+```text
+<controllerHome>/repositories/<repoId>/controller/access-policy.json
+```
+
+The setting is not written to the repository and is not committed to Git. A missing or malformed file safely falls back to `request`.
+
+Each durable WorkContract captures its effective `accessMode` in `constraints`. Changing the repository default affects new work; an existing task keeps its captured mode.
+
+## MCP tools
+
+The controller core toolset exposes:
+
+- `repository_access_get`
+- `repository_access_set`
+
+Enabling Full Access requires both:
+
+```json
+{
+  "mode": "full_access",
+  "confirm_authorization": true,
+  "confirmation_text": "enable-full-access"
+}
+```
+
+Downgrading to Request is also an explicit write action:
+
+```json
+{
+  "mode": "request",
+  "confirm_authorization": true
+}
+```
+
+## Per-task override
+
+`rh_work` already accepts a generic `constraints` object. A caller may select a mode for one task without changing the repository default:
+
+```json
+{
+  "operation": "start",
+  "objective": "Refactor the local controller routing",
+  "constraints": {
+    "accessMode": "full_access"
+  }
+}
+```
+
+Both camelCase and snake_case are accepted inside constraints:
+
+```json
+{
+  "constraints": {
+    "access_mode": "request"
+  }
+}
+```
+
+The response includes `accessMode`, `accessModeLabel`, and `accessModeDescription`, and a created work summary includes the captured mode.
+
+## Decision matrix
+
+| Effect | Request | Full Access |
+| --- | --- | --- |
+| Read selected repository | allow | allow |
+| Bounded Direct Control edit | allow | allow |
+| General repository/workspace write | request | allow |
+| Repository-scoped local command | request | allow |
+| Dependency change | request | allow |
+| Local Git write | request | allow |
+| External network | request | request |
+| Remote write / push | request | request |
+| Destructive effect | strong confirmation | strong confirmation |
+| Raw secrets or credentials | deny | deny |
+| Outside-repository path | request | request |
+
+## Compatibility
+
+Existing callers that do not send an access mode retain the previous safe behavior because the default is `request`. Existing approval fields and hard authorization checks remain in force.

--- a/src/cli/mcp/access-tools.ts
+++ b/src/cli/mcp/access-tools.ts
@@ -1,0 +1,157 @@
+import {
+  accessModeDescriptor,
+  isAccessMode,
+  readRepositoryAccessPolicy,
+  writeRepositoryAccessPolicy,
+} from '../../runtime/control-plane/governance/access-policy';
+import type { MultiRepositoryMcpToolContext } from './multi-repository';
+import { resolveRepositorySelection } from '../repositories/registry';
+import type { CallToolResult, McpToolDefinition } from './tools';
+
+function definition(
+  name: string,
+  description: string,
+  properties: Record<string, unknown>,
+  required: string[] = [],
+  readOnlyHint = true,
+): McpToolDefinition {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: 'object',
+      properties,
+      ...(required.length ? { required } : {}),
+      additionalProperties: false,
+    },
+    annotations: {
+      readOnlyHint,
+      openWorldHint: false,
+      destructiveHint: false,
+    },
+  };
+}
+
+const repoId = { type: 'string', description: 'Stable repository id. Omit when exactly one repository is selected.' };
+
+export const accessToolDefinitions: McpToolDefinition[] = [
+  definition(
+    'repository_access_get',
+    'Read the Request or Full Access permission level for the selected repository.',
+    { repo_id: repoId },
+  ),
+  definition(
+    'repository_access_set',
+    'Set the selected repository permission level. Full Access covers local repository work only; remote, destructive, outside-repository, and secret access remain gated.',
+    {
+      repo_id: repoId,
+      mode: {
+        type: 'string',
+        enum: ['request', 'full_access'],
+        description: 'Request asks before elevated local effects. Full Access permits normal local repository work without repeated approval prompts.',
+      },
+      confirm_authorization: {
+        type: 'boolean',
+        description: 'Must be true to change the repository permission level.',
+      },
+      confirmation_text: {
+        type: 'string',
+        description: 'Required when enabling Full Access; must equal enable-full-access.',
+      },
+    },
+    ['mode', 'confirm_authorization'],
+    false,
+  ),
+];
+
+export const accessToolNames = accessToolDefinitions.map((tool) => tool.name);
+
+function selected(ctx: MultiRepositoryMcpToolContext, args: Record<string, unknown>) {
+  return resolveRepositorySelection({
+    repoId: typeof args.repo_id === 'string' ? args.repo_id : undefined,
+    explicitPath: ctx.explicitRepository?.canonicalRoot,
+    controllerHome: ctx.controllerHome,
+    allowSoleRepository: true,
+  });
+}
+
+function result(value: Record<string, unknown>, isError = false): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+export function callAccessTool(
+  ctx: MultiRepositoryMcpToolContext,
+  name: string,
+  args: Record<string, unknown>,
+): CallToolResult | null {
+  if (!accessToolNames.includes(name)) return null;
+  try {
+    const repository = selected(ctx, args);
+    if (name === 'repository_access_get') {
+      const policy = readRepositoryAccessPolicy(ctx.controllerHome, repository.repoId);
+      return result({
+        repository: {
+          repoId: repository.repoId,
+          name: repository.displayName,
+        },
+        policy,
+        descriptor: accessModeDescriptor(policy.mode),
+        scope: 'repository',
+        storage: 'controllerHome',
+      });
+    }
+
+    const mode = args.mode;
+    if (!isAccessMode(mode)) {
+      return result({
+        error: {
+          code: 'ACCESS_MODE_INVALID',
+          message: 'mode must be request or full_access',
+        },
+      }, true);
+    }
+    if (args.confirm_authorization !== true) {
+      return result({
+        error: {
+          code: 'ACCESS_MODE_AUTHORIZATION_REQUIRED',
+          message: 'confirm_authorization must be true before changing repository access.',
+        },
+      }, true);
+    }
+    if (mode === 'full_access' && args.confirmation_text !== 'enable-full-access') {
+      return result({
+        error: {
+          code: 'FULL_ACCESS_STRONG_CONFIRMATION_REQUIRED',
+          message: 'confirmation_text must equal enable-full-access.',
+        },
+      }, true);
+    }
+
+    const policy = writeRepositoryAccessPolicy(ctx.controllerHome, repository.repoId, mode, 'user');
+    return result({
+      repository: {
+        repoId: repository.repoId,
+        name: repository.displayName,
+      },
+      policy,
+      descriptor: accessModeDescriptor(policy.mode),
+      scope: 'repository',
+      storage: 'controllerHome',
+      warning: mode === 'full_access'
+        ? 'Full Access applies only to local work in this repository. Remote writes, destructive actions, outside-repository paths, and raw secrets remain gated.'
+        : 'Request mode is active; elevated local effects will ask for approval.',
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return result({
+      error: {
+        code: message.includes(':') ? message.slice(0, message.indexOf(':')) : 'ACCESS_POLICY_FAILED',
+        message,
+      },
+    }, true);
+  }
+}

--- a/src/cli/mcp/server.ts
+++ b/src/cli/mcp/server.ts
@@ -10,8 +10,9 @@ import {
   type McpServerOptions,
   type MultiRepositoryMcpToolContext,
 } from './multi-repository';
-import { callRepositoryTool, repositoryToolDefinitions } from './repository-tools';
-import { callRuntimeTool, runtimeToolDefinitions } from '../../runtime/gateway/mcp/runtime-tools';
+import { callAccessTool } from './access-tools';
+import { callRepositoryTool } from './repository-tools';
+import { callRuntimeTool } from '../../runtime/gateway/mcp/runtime-tools';
 import { injectDurableCommandFields, routeDurableMcpCall } from '../../runtime/gateway/mcp/router';
 import { exposedControllerToolDefinitions, isControllerToolExposed } from './toolset';
 
@@ -53,6 +54,8 @@ export function createRepoHarnessMcpServerFromContext(ctx: ServerToolContext): S
         const value = { error: { code: 'TOOL_NOT_EXPOSED', message: `${name} is not exposed by the ${ctx.toolset} MCP toolset.` } };
         return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }], structuredContent: value, isError: true };
       }
+      const accessResult = callAccessTool(ctx, name, args);
+      if (accessResult) return accessResult;
       const runtimeResult = await callRuntimeTool(ctx, name, args);
       if (runtimeResult) return runtimeResult;
       const durableResult = await routeDurableMcpCall(ctx, name, args);

--- a/src/cli/mcp/toolset.ts
+++ b/src/cli/mcp/toolset.ts
@@ -1,6 +1,7 @@
 import type { McpToolDefinition } from './tools';
 import type { MultiRepositoryMcpToolContext } from './multi-repository';
 import { buildMultiRepositoryToolDefinitions } from './multi-repository';
+import { accessToolDefinitions } from './access-tools';
 import { repositoryToolDefinitions } from './repository-tools';
 import { runtimeToolDefinitions } from '../../runtime/gateway/mcp/runtime-tools';
 import { FACADE_TOOLS } from '../../runtime/control-plane/facade/types';
@@ -20,6 +21,8 @@ export const DEFAULT_CONTROLLER_TOOL_NAMES = [
   'rh_inbox',
   'rh_context',
   'rh_work',
+  'repository_access_get',
+  'repository_access_set',
   'repository_list',
   'repository_get',
   'repository_register',
@@ -148,7 +151,7 @@ export function controllerToolExposureMetadata(toolNames: readonly string[]): {
 }
 
 export function allControllerToolDefinitions(ctx: MultiRepositoryMcpToolContext): McpToolDefinition[] {
-  return runtimeToolDefinitions.concat(repositoryToolDefinitions, buildMultiRepositoryToolDefinitions(ctx));
+  return runtimeToolDefinitions.concat(accessToolDefinitions, repositoryToolDefinitions, buildMultiRepositoryToolDefinitions(ctx));
 }
 
 export function exposedControllerToolDefinitions(ctx: MultiRepositoryMcpToolContext): McpToolDefinition[] {

--- a/src/runtime/control-plane/facade/goal-workloop-access.ts
+++ b/src/runtime/control-plane/facade/goal-workloop-access.ts
@@ -1,0 +1,141 @@
+import {
+  isAccessMode,
+  normalizeAccessMode,
+  readRepositoryAccessPolicy,
+  withAccessMode,
+  type AccessMode,
+} from '../governance/access-policy';
+import {
+  routeWorkStart as routeWorkStartBase,
+  runGoalWorkloop as runGoalWorkloopBase,
+  type GoalWorkloopContext,
+  type GoalWorkloopOperation,
+  type GoalWorkloopStartInput,
+} from './goal-workloop';
+import type { CapabilityRisk, FacadeResult, WorkContractConstraints } from './types';
+
+export {
+  continueGoalWorkloop,
+  finalizeGoalWorkloop,
+  startGoalWorkloop,
+  stopGoalWorkloop,
+  verifyGoalWorkloop,
+  type GoalWorkloopContext,
+  type GoalWorkloopContinueInput,
+  type GoalWorkloopFinalizeInput,
+  type GoalWorkloopOperation,
+  type GoalWorkloopStartInput,
+  type GoalWorkloopStopInput,
+  type GoalWorkloopVerifyInput,
+} from './goal-workloop';
+
+function booleanValue(record: Record<string, unknown>, camel: string, snake: string): boolean | undefined {
+  const value = record[camel] ?? record[snake];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function numberValue(record: Record<string, unknown>, camel: string, snake: string): number | undefined {
+  const value = record[camel] ?? record[snake];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function accessModeValue(value: unknown): AccessMode | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const candidate = record.accessMode ?? record.access_mode;
+  return isAccessMode(candidate) ? candidate : undefined;
+}
+
+function constraintsValue(value: unknown): WorkContractConstraints | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const constraints: WorkContractConstraints = {
+    maxChangedFiles: numberValue(record, 'maxChangedFiles', 'max_changed_files'),
+    maxChangedLines: numberValue(record, 'maxChangedLines', 'max_changed_lines'),
+    allowCommit: booleanValue(record, 'allowCommit', 'allow_commit'),
+    allowMerge: booleanValue(record, 'allowMerge', 'allow_merge'),
+    allowCleanup: booleanValue(record, 'allowCleanup', 'allow_cleanup'),
+    allowDestructive: booleanValue(record, 'allowDestructive', 'allow_destructive'),
+    requireHandoffOnAmbiguity: booleanValue(record, 'requireHandoffOnAmbiguity', 'require_handoff_on_ambiguity'),
+    accessMode: accessModeValue(record),
+  };
+  return Object.fromEntries(
+    Object.entries(constraints).filter(([, entry]) => entry !== undefined),
+  ) as WorkContractConstraints;
+}
+
+function repositoryDefaultMode(ctx: GoalWorkloopContext): AccessMode {
+  const controllerHome = ctx.workStore.controllerHome;
+  if (!controllerHome) return 'request';
+  return readRepositoryAccessPolicy(controllerHome, ctx.repoId).mode;
+}
+
+function resolveMode(ctx: GoalWorkloopContext, constraints?: WorkContractConstraints): AccessMode {
+  return normalizeAccessMode(constraints?.accessMode, repositoryDefaultMode(ctx));
+}
+
+function normalizeStartInput(ctx: GoalWorkloopContext, input: GoalWorkloopStartInput): GoalWorkloopStartInput {
+  const accessMode = resolveMode(ctx, input.constraints);
+  return {
+    ...input,
+    constraints: {
+      requireHandoffOnAmbiguity: true,
+      ...input.constraints,
+      accessMode,
+    },
+  };
+}
+
+export function routeWorkStart(ctx: GoalWorkloopContext, input: GoalWorkloopStartInput): FacadeResult {
+  const normalized = normalizeStartInput(ctx, input);
+  return withAccessMode(normalized.constraints?.accessMode ?? 'request', () => routeWorkStartBase(ctx, normalized));
+}
+
+export function runGoalWorkloop(
+  ctx: GoalWorkloopContext,
+  operation: GoalWorkloopOperation,
+  args: Record<string, unknown>,
+): FacadeResult {
+  if (operation !== 'start') {
+    return withAccessMode(repositoryDefaultMode(ctx), () => runGoalWorkloopBase(ctx, operation, args));
+  }
+
+  const constraints = constraintsValue(args.constraints);
+  return routeWorkStart(ctx, {
+    objective: String(args.objective ?? ''),
+    acceptanceCriteria: Array.isArray(args.acceptance_criteria) ? args.acceptance_criteria.map(String) : undefined,
+    allowedPaths: Array.isArray(args.allowed_paths) ? args.allowed_paths.map(String) : undefined,
+    forbiddenPaths: Array.isArray(args.forbidden_paths) ? args.forbidden_paths.map(String) : undefined,
+    checks: Array.isArray(args.check_ids) ? args.check_ids.map(String) : undefined,
+    constraints,
+    modeInput: {
+      objective: typeof args.objective === 'string' ? args.objective : undefined,
+      expectedFiles: typeof args.expected_files === 'number' ? args.expected_files : undefined,
+      expectedChangedLines: typeof args.expected_changed_lines === 'number' ? args.expected_changed_lines : undefined,
+      scopeClear: args.scope_clear === undefined ? true : args.scope_clear === true,
+      requiresInvestigation: args.requires_investigation === true,
+      requiresLongRunningChecks: args.requires_long_running_checks === true,
+      requiresParallelism: args.requires_parallelism === true,
+      needsDependencies: args.needs_dependencies === true,
+      requiresRecovery: args.requires_recovery === true,
+      requiresWorker: args.requires_worker === true,
+      requiresExternalEffect: args.requires_external_effect === true,
+      requiresApproval: args.requires_approval === true,
+      requiresUserApproval: args.requires_user_approval === true,
+      destructive: args.destructive === true,
+      remoteWrite: args.remote_write === true,
+      secretAccess: args.secret_access === true,
+      risk: typeof args.risk === 'string' ? args.risk as CapabilityRisk : undefined,
+    },
+    requestedBy: args.requested_by === 'user' || args.requested_by === 'system' || args.requested_by === 'scheduler'
+      ? args.requested_by
+      : 'chatgpt',
+    taskId: typeof args.task_id === 'string' ? args.task_id : undefined,
+    issueId: typeof args.issue_id === 'string' ? args.issue_id : undefined,
+    approvalConfirmed: args.approval_confirmed === true,
+    dryRun: args.dry_run === true,
+    forceMode: args.force_mode === 'direct_control' || args.force_mode === 'goal_workloop' || args.force_mode === 'handoff_only'
+      ? args.force_mode
+      : undefined,
+  });
+}

--- a/src/runtime/control-plane/facade/goal-workloop-access.ts
+++ b/src/runtime/control-plane/facade/goal-workloop-access.ts
@@ -1,4 +1,5 @@
 import {
+  accessModeDescriptor,
   isAccessMode,
   normalizeAccessMode,
   readRepositoryAccessPolicy,
@@ -12,6 +13,7 @@ import {
   type GoalWorkloopOperation,
   type GoalWorkloopStartInput,
 } from './goal-workloop';
+import { getWorkContract } from './work-contract-store';
 import type { CapabilityRisk, FacadeResult, WorkContractConstraints } from './types';
 
 export {
@@ -86,9 +88,33 @@ function normalizeStartInput(ctx: GoalWorkloopContext, input: GoalWorkloopStartI
   };
 }
 
+function decorateAccessMode(result: FacadeResult, mode: AccessMode): FacadeResult {
+  const descriptor = accessModeDescriptor(mode);
+  const work = result.data.work;
+  return {
+    ...result,
+    data: {
+      ...result.data,
+      accessMode: mode,
+      accessModeLabel: descriptor.shortLabel,
+      accessModeDescription: descriptor.description,
+      ...(work && typeof work === 'object' && !Array.isArray(work)
+        ? {
+            work: {
+              ...(work as Record<string, unknown>),
+              accessMode: mode,
+              accessModeLabel: descriptor.shortLabel,
+            },
+          }
+        : {}),
+    },
+  };
+}
+
 export function routeWorkStart(ctx: GoalWorkloopContext, input: GoalWorkloopStartInput): FacadeResult {
   const normalized = normalizeStartInput(ctx, input);
-  return withAccessMode(normalized.constraints?.accessMode ?? 'request', () => routeWorkStartBase(ctx, normalized));
+  const mode = normalized.constraints?.accessMode ?? 'request';
+  return withAccessMode(mode, () => decorateAccessMode(routeWorkStartBase(ctx, normalized), mode));
 }
 
 export function runGoalWorkloop(
@@ -97,7 +123,10 @@ export function runGoalWorkloop(
   args: Record<string, unknown>,
 ): FacadeResult {
   if (operation !== 'start') {
-    return withAccessMode(repositoryDefaultMode(ctx), () => runGoalWorkloopBase(ctx, operation, args));
+    const workId = typeof args.work_id === 'string' ? args.work_id : '';
+    const existing = workId ? getWorkContract(ctx.workStore, workId) : undefined;
+    const mode = resolveMode(ctx, existing?.constraints);
+    return withAccessMode(mode, () => decorateAccessMode(runGoalWorkloopBase(ctx, operation, args), mode));
   }
 
   const constraints = constraintsValue(args.constraints);

--- a/src/runtime/control-plane/facade/index.ts
+++ b/src/runtime/control-plane/facade/index.ts
@@ -6,7 +6,7 @@ export * from './suggested-actions';
 export * from './capability-registry';
 export * from './policy-gate';
 export * from './check-normalization';
-export * from './goal-workloop';
+export * from './goal-workloop-access';
 export * from './codex-delegation';
 export * from './self-healing-loop';
 export * from './operation-digest';

--- a/src/runtime/control-plane/facade/policy-gate.ts
+++ b/src/runtime/control-plane/facade/policy-gate.ts
@@ -1,3 +1,9 @@
+import {
+  evaluateAccessMode,
+  normalizeAccessMode,
+  type AccessEffect,
+  type AccessMode,
+} from '../governance/access-policy';
 import type { CapabilityDescriptor, CapabilityRisk, PolicyDecision, SuggestedNextAction } from './types';
 
 export type PolicySideEffect =
@@ -20,6 +26,7 @@ export interface PolicyGateInput {
   capabilityId?: string;
   risk?: CapabilityRisk;
   sideEffect?: PolicySideEffect;
+  accessMode?: AccessMode;
   approvalConfirmed?: boolean;
   dryRun?: boolean;
   directEditBoundary?: DirectEditBoundary;
@@ -46,6 +53,15 @@ function sideEffectFromRisk(risk: CapabilityRisk | undefined): PolicySideEffect 
   return 'workspace_write';
 }
 
+function accessEffectFromSideEffect(sideEffect: PolicySideEffect): AccessEffect {
+  if (sideEffect === 'none') return 'read';
+  if (sideEffect === 'local_repo_write') return 'local_repo_write';
+  if (sideEffect === 'workspace_write') return 'workspace_write';
+  if (sideEffect === 'remote_write') return 'remote_write';
+  if (sideEffect === 'destructive_remote') return 'destructive';
+  return 'secret_access';
+}
+
 function directEditWithinBoundary(boundary: DirectEditBoundary | undefined): boolean {
   if (!boundary) return false;
   return boundary.scopeClear && boundary.pathsExplicit === true && (boundary.maxChangedFiles ?? 99) <= 3 && (boundary.maxChangedLines ?? 9999) <= 200;
@@ -55,6 +71,7 @@ export function evaluatePolicyGate(input: PolicyGateInput): PolicyDecision {
   const capabilityId = input.capability?.capabilityId ?? input.capabilityId;
   const risk = input.risk ?? input.capability?.risk;
   const sideEffect = input.sideEffect ?? sideEffectFromRisk(risk);
+  const accessMode = normalizeAccessMode(input.accessMode);
   const warnings: string[] = [];
 
   if (input.dryRun) {
@@ -79,6 +96,16 @@ export function evaluatePolicyGate(input: PolicyGateInput): PolicyDecision {
 
   if (sideEffect === 'none') {
     return { decision: 'allowed', reason: 'Readonly bounded facade operation.', capabilityId, warnings, suggestedNextActions: [] };
+  }
+
+  if (evaluateAccessMode(accessMode, accessEffectFromSideEffect(sideEffect)) === 'allow') {
+    return {
+      decision: 'allowed',
+      reason: 'Full Access permits this local repository operation without another approval prompt.',
+      capabilityId,
+      warnings: ['Remote writes, destructive actions, outside-repository access, and raw secrets remain separately gated.'],
+      suggestedNextActions: [],
+    };
   }
 
   if (sideEffect === 'local_repo_write' && directEditWithinBoundary(input.directEditBoundary)) {
@@ -114,7 +141,9 @@ export function evaluatePolicyGate(input: PolicyGateInput): PolicyDecision {
 
   return {
     decision: 'approval_required',
-    reason: 'Side-effecting operations require policy-gate approval unless they fit the bounded Direct Control path.',
+    reason: accessMode === 'request'
+      ? 'Request mode requires approval for side effects outside the bounded Direct Control path.'
+      : 'This operation is outside the local repository permissions granted by Full Access.',
     capabilityId,
     warnings,
     suggestedNextActions: [approvalAction('Approval is required before execution.', capabilityId)],

--- a/src/runtime/control-plane/facade/policy-gate.ts
+++ b/src/runtime/control-plane/facade/policy-gate.ts
@@ -1,4 +1,5 @@
 import {
+  currentAccessMode,
   evaluateAccessMode,
   normalizeAccessMode,
   type AccessEffect,
@@ -71,7 +72,7 @@ export function evaluatePolicyGate(input: PolicyGateInput): PolicyDecision {
   const capabilityId = input.capability?.capabilityId ?? input.capabilityId;
   const risk = input.risk ?? input.capability?.risk;
   const sideEffect = input.sideEffect ?? sideEffectFromRisk(risk);
-  const accessMode = normalizeAccessMode(input.accessMode);
+  const accessMode = normalizeAccessMode(input.accessMode ?? currentAccessMode());
   const warnings: string[] = [];
 
   if (input.dryRun) {

--- a/src/runtime/control-plane/governance/access-policy.ts
+++ b/src/runtime/control-plane/governance/access-policy.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'async_hooks';
 import {
   existsSync,
   mkdirSync,
@@ -9,6 +10,8 @@ import { dirname, join, resolve } from 'path';
 
 export const ACCESS_MODES = ['request', 'full_access'] as const;
 export type AccessMode = (typeof ACCESS_MODES)[number];
+
+const accessModeContext = new AsyncLocalStorage<AccessMode>();
 
 declare module '../facade/types' {
   interface WorkContractConstraints {
@@ -77,6 +80,14 @@ export function isAccessMode(value: unknown): value is AccessMode {
 
 export function normalizeAccessMode(value: unknown, fallback: AccessMode = 'request'): AccessMode {
   return isAccessMode(value) ? value : fallback;
+}
+
+export function currentAccessMode(): AccessMode | undefined {
+  return accessModeContext.getStore();
+}
+
+export function withAccessMode<T>(mode: AccessMode, operation: () => T): T {
+  return accessModeContext.run(mode, operation);
 }
 
 export function repositoryAccessPolicyPath(controllerHome: string, repoId: string): string {

--- a/src/runtime/control-plane/governance/access-policy.ts
+++ b/src/runtime/control-plane/governance/access-policy.ts
@@ -1,0 +1,150 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, join, resolve } from 'path';
+
+export const ACCESS_MODES = ['request', 'full_access'] as const;
+export type AccessMode = (typeof ACCESS_MODES)[number];
+
+export type AccessEffect =
+  | 'read'
+  | 'local_repo_write'
+  | 'workspace_write'
+  | 'local_command'
+  | 'dependency_change'
+  | 'local_git'
+  | 'external_network'
+  | 'remote_write'
+  | 'destructive'
+  | 'secret_access'
+  | 'outside_repository';
+
+export type AccessDecision = 'allow' | 'request' | 'deny';
+
+export interface RepositoryAccessPolicy {
+  schemaVersion: 1;
+  repoId: string;
+  mode: AccessMode;
+  updatedAt: string;
+  updatedBy: 'user' | 'system';
+}
+
+export interface AccessModeDescriptor {
+  mode: AccessMode;
+  label: string;
+  shortLabel: string;
+  description: string;
+  automaticallyAllowed: string[];
+  stillRequiresApproval: string[];
+  alwaysDenied: string[];
+}
+
+export const ACCESS_MODE_DESCRIPTORS: Record<AccessMode, AccessModeDescriptor> = {
+  request: {
+    mode: 'request',
+    label: 'Request — 需要时请求权限',
+    shortLabel: 'Request',
+    description: '在当前仓库的安全边界内执行；命令、依赖、本地 Git 或其他提升权限的动作会先请求确认。',
+    automaticallyAllowed: ['读取和搜索当前仓库', '受控路径内的小范围修改', '已注册的检查和只读诊断'],
+    stillRequiresApproval: ['任意本地命令', '安装或更新依赖', '本地 Git 写操作', '网络和远程写入'],
+    alwaysDenied: ['读取原始密钥或凭据', '绕过 controller 策略'],
+  },
+  full_access: {
+    mode: 'full_access',
+    label: 'Full Access — 当前仓库完全访问',
+    shortLabel: 'Full Access',
+    description: '允许在当前仓库内编辑文件、运行本地命令、调整依赖和执行本地 Git；远程、破坏性和密钥操作仍需审批或保持禁止。',
+    automaticallyAllowed: ['当前仓库内文件读写', '仓库范围本地命令', '依赖变更', '本地 Git 和检查'],
+    stillRequiresApproval: ['仓库外路径', '外部网络访问', 'Git push 或远程服务写入', '不可逆或破坏性操作'],
+    alwaysDenied: ['读取原始密钥或凭据', '直接修改 controllerHome 安全状态', '绕过 managed policy'],
+  },
+};
+
+export function isAccessMode(value: unknown): value is AccessMode {
+  return value === 'request' || value === 'full_access';
+}
+
+export function normalizeAccessMode(value: unknown, fallback: AccessMode = 'request'): AccessMode {
+  return isAccessMode(value) ? value : fallback;
+}
+
+export function repositoryAccessPolicyPath(controllerHome: string, repoId: string): string {
+  return join(resolve(controllerHome), 'repositories', repoId, 'controller', 'access-policy.json');
+}
+
+function defaultPolicy(repoId: string): RepositoryAccessPolicy {
+  return {
+    schemaVersion: 1,
+    repoId,
+    mode: 'request',
+    updatedAt: new Date(0).toISOString(),
+    updatedBy: 'system',
+  };
+}
+
+export function readRepositoryAccessPolicy(controllerHome: string, repoId: string): RepositoryAccessPolicy {
+  const path = repositoryAccessPolicyPath(controllerHome, repoId);
+  if (!existsSync(path)) return defaultPolicy(repoId);
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<RepositoryAccessPolicy>;
+    return {
+      schemaVersion: 1,
+      repoId,
+      mode: normalizeAccessMode(parsed.mode),
+      updatedAt: typeof parsed.updatedAt === 'string' && parsed.updatedAt.trim()
+        ? parsed.updatedAt
+        : new Date(0).toISOString(),
+      updatedBy: parsed.updatedBy === 'user' ? 'user' : 'system',
+    };
+  } catch {
+    return defaultPolicy(repoId);
+  }
+}
+
+export function writeRepositoryAccessPolicy(
+  controllerHome: string,
+  repoId: string,
+  mode: AccessMode,
+  updatedBy: RepositoryAccessPolicy['updatedBy'] = 'user',
+): RepositoryAccessPolicy {
+  const path = repositoryAccessPolicyPath(controllerHome, repoId);
+  mkdirSync(dirname(path), { recursive: true });
+  const policy: RepositoryAccessPolicy = {
+    schemaVersion: 1,
+    repoId,
+    mode,
+    updatedAt: new Date().toISOString(),
+    updatedBy,
+  };
+  const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(policy, null, 2)}\n`, { encoding: 'utf-8', mode: 0o600 });
+  renameSync(tempPath, path);
+  return policy;
+}
+
+export function evaluateAccessMode(mode: AccessMode, effect: AccessEffect): AccessDecision {
+  if (effect === 'read') return 'allow';
+  if (effect === 'secret_access') return 'deny';
+
+  if (mode === 'full_access') {
+    if (
+      effect === 'local_repo_write'
+      || effect === 'workspace_write'
+      || effect === 'local_command'
+      || effect === 'dependency_change'
+      || effect === 'local_git'
+    ) {
+      return 'allow';
+    }
+  }
+
+  return 'request';
+}
+
+export function accessModeDescriptor(mode: AccessMode): AccessModeDescriptor {
+  return ACCESS_MODE_DESCRIPTORS[mode];
+}

--- a/src/runtime/control-plane/governance/access-policy.ts
+++ b/src/runtime/control-plane/governance/access-policy.ts
@@ -10,6 +10,13 @@ import { dirname, join, resolve } from 'path';
 export const ACCESS_MODES = ['request', 'full_access'] as const;
 export type AccessMode = (typeof ACCESS_MODES)[number];
 
+declare module '../facade/types' {
+  interface WorkContractConstraints {
+    /** Permission snapshot captured when the work starts. Defaults to request. */
+    accessMode?: AccessMode;
+  }
+}
+
 export type AccessEffect =
   | 'read'
   | 'local_repo_write'

--- a/tests/access-policy.test.ts
+++ b/tests/access-policy.test.ts
@@ -9,6 +9,13 @@ import {
   repositoryAccessPolicyPath,
   writeRepositoryAccessPolicy,
 } from '../src/runtime/control-plane/governance/access-policy';
+import {
+  getWorkContract,
+  listHandoffItems,
+  routeWorkStart,
+  runGoalWorkloop,
+  type GoalWorkloopContext,
+} from '../src/runtime/control-plane/facade';
 import { evaluatePolicyGate } from '../src/runtime/control-plane/facade/policy-gate';
 
 const tempRoots: string[] = [];
@@ -17,6 +24,16 @@ function controllerHome(): string {
   const root = mkdtempSync(join(tmpdir(), 'repo-harness-access-policy-'));
   tempRoots.push(root);
   return root;
+}
+
+function workloopContext(home: string): GoalWorkloopContext {
+  const store = { controllerHome: home, repoId: 'repo-test' };
+  return {
+    workStore: store,
+    handoffStore: store,
+    repoId: 'repo-test',
+    availableChecks: [],
+  };
 }
 
 afterEach(() => {
@@ -108,5 +125,69 @@ describe('policy gate access mode integration', () => {
     expect(evaluatePolicyGate({ risk: 'remote_write', accessMode: 'full_access' }).decision).toBe('approval_required');
     expect(evaluatePolicyGate({ risk: 'destructive', accessMode: 'full_access' }).decision).toBe('approval_required');
     expect(evaluatePolicyGate({ risk: 'raw_secret_config', accessMode: 'full_access' }).decision).toBe('denied');
+  });
+});
+
+describe('access-aware work routing', () => {
+  test('request mode creates an approval handoff for explicitly approval-gated work', () => {
+    const home = controllerHome();
+    const ctx = workloopContext(home);
+    const result = routeWorkStart(ctx, {
+      objective: 'Update several local repository files',
+      modeInput: {
+        objective: 'Update several local repository files',
+        scopeClear: true,
+        expectedFiles: 4,
+        requiresApproval: true,
+      },
+      requestedBy: 'user',
+    });
+
+    expect(result.status).toBe('approval_required');
+    expect(result.data.workContractCreated).toBe(false);
+    expect(listHandoffItems({ controllerHome: home, repoId: 'repo-test', status: 'pending' })).toHaveLength(1);
+  });
+
+  test('repository full access creates work and captures the permission snapshot', () => {
+    const home = controllerHome();
+    const ctx = workloopContext(home);
+    writeRepositoryAccessPolicy(home, 'repo-test', 'full_access');
+
+    const result = routeWorkStart(ctx, {
+      objective: 'Update several local repository files',
+      modeInput: {
+        objective: 'Update several local repository files',
+        scopeClear: true,
+        expectedFiles: 4,
+        requiresApproval: true,
+      },
+      requestedBy: 'user',
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.data.workContractCreated).toBe(true);
+    const workId = String((result.data.work as { workId?: string }).workId ?? '');
+    const work = getWorkContract({ controllerHome: home, repoId: 'repo-test' }, workId);
+    expect(work?.constraints.accessMode).toBe('full_access');
+    expect(work?.policyDecisions[0]?.reason).toContain('Full Access');
+  });
+
+  test('rh_work constraints may override the repository default for one task', () => {
+    const home = controllerHome();
+    const ctx = workloopContext(home);
+
+    const result = runGoalWorkloop(ctx, 'start', {
+      objective: 'Update several local repository files',
+      expected_files: 4,
+      scope_clear: true,
+      requires_approval: true,
+      constraints: { accessMode: 'full_access' },
+      requested_by: 'user',
+    });
+
+    expect(result.status).toBe('ok');
+    const workId = String((result.data.work as { workId?: string }).workId ?? '');
+    expect(getWorkContract({ controllerHome: home, repoId: 'repo-test' }, workId)?.constraints.accessMode).toBe('full_access');
+    expect(readRepositoryAccessPolicy(home, 'repo-test').mode).toBe('request');
   });
 });

--- a/tests/access-policy.test.ts
+++ b/tests/access-policy.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  accessModeDescriptor,
+  evaluateAccessMode,
+  readRepositoryAccessPolicy,
+  repositoryAccessPolicyPath,
+  writeRepositoryAccessPolicy,
+} from '../src/runtime/control-plane/governance/access-policy';
+import { evaluatePolicyGate } from '../src/runtime/control-plane/facade/policy-gate';
+
+const tempRoots: string[] = [];
+
+function controllerHome(): string {
+  const root = mkdtempSync(join(tmpdir(), 'repo-harness-access-policy-'));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('repository access policy', () => {
+  test('defaults to request without writing controller state', () => {
+    const home = controllerHome();
+    const policy = readRepositoryAccessPolicy(home, 'repo-test');
+
+    expect(policy.mode).toBe('request');
+    expect(policy.updatedBy).toBe('system');
+    expect(repositoryAccessPolicyPath(home, 'repo-test')).toEndWith(
+      join('repositories', 'repo-test', 'controller', 'access-policy.json'),
+    );
+  });
+
+  test('persists full access under controllerHome repository storage', () => {
+    const home = controllerHome();
+    const written = writeRepositoryAccessPolicy(home, 'repo-test', 'full_access');
+    const loaded = readRepositoryAccessPolicy(home, 'repo-test');
+
+    expect(written.mode).toBe('full_access');
+    expect(written.updatedBy).toBe('user');
+    expect(loaded).toEqual(written);
+  });
+
+  test('falls back to request for malformed policy files', () => {
+    const home = controllerHome();
+    writeRepositoryAccessPolicy(home, 'repo-test', 'full_access');
+    const path = repositoryAccessPolicyPath(home, 'repo-test');
+    Bun.write(path, '{invalid-json');
+
+    expect(readRepositoryAccessPolicy(home, 'repo-test').mode).toBe('request');
+  });
+});
+
+describe('access decision matrix', () => {
+  test('request allows reads and requests local side effects', () => {
+    expect(evaluateAccessMode('request', 'read')).toBe('allow');
+    expect(evaluateAccessMode('request', 'local_repo_write')).toBe('request');
+    expect(evaluateAccessMode('request', 'local_command')).toBe('request');
+    expect(evaluateAccessMode('request', 'local_git')).toBe('request');
+  });
+
+  test('full access allows local repository work only', () => {
+    expect(evaluateAccessMode('full_access', 'local_repo_write')).toBe('allow');
+    expect(evaluateAccessMode('full_access', 'workspace_write')).toBe('allow');
+    expect(evaluateAccessMode('full_access', 'local_command')).toBe('allow');
+    expect(evaluateAccessMode('full_access', 'dependency_change')).toBe('allow');
+    expect(evaluateAccessMode('full_access', 'local_git')).toBe('allow');
+    expect(evaluateAccessMode('full_access', 'external_network')).toBe('request');
+    expect(evaluateAccessMode('full_access', 'remote_write')).toBe('request');
+    expect(evaluateAccessMode('full_access', 'destructive')).toBe('request');
+    expect(evaluateAccessMode('full_access', 'outside_repository')).toBe('request');
+    expect(evaluateAccessMode('full_access', 'secret_access')).toBe('deny');
+  });
+
+  test('descriptors explain the remaining hard boundaries', () => {
+    const full = accessModeDescriptor('full_access');
+    expect(full.shortLabel).toBe('Full Access');
+    expect(full.stillRequiresApproval.join(' ')).toContain('远程');
+    expect(full.alwaysDenied.join(' ')).toContain('密钥');
+  });
+});
+
+describe('policy gate access mode integration', () => {
+  test('full access removes repeated approval for local writes', () => {
+    expect(evaluatePolicyGate({ risk: 'workspace_write', accessMode: 'full_access' }).decision).toBe('allowed');
+    expect(evaluatePolicyGate({ risk: 'local_repo_write', accessMode: 'full_access' }).decision).toBe('allowed');
+  });
+
+  test('request still requires approval outside bounded direct edits', () => {
+    expect(evaluatePolicyGate({ risk: 'workspace_write', accessMode: 'request' }).decision).toBe('approval_required');
+    expect(evaluatePolicyGate({
+      risk: 'local_repo_write',
+      accessMode: 'request',
+      directEditBoundary: {
+        scopeClear: true,
+        pathsExplicit: true,
+        maxChangedFiles: 2,
+        maxChangedLines: 100,
+      },
+    }).decision).toBe('allowed');
+  });
+
+  test('full access cannot bypass remote destructive or secret gates', () => {
+    expect(evaluatePolicyGate({ risk: 'remote_write', accessMode: 'full_access' }).decision).toBe('approval_required');
+    expect(evaluatePolicyGate({ risk: 'destructive', accessMode: 'full_access' }).decision).toBe('approval_required');
+    expect(evaluatePolicyGate({ risk: 'raw_secret_config', accessMode: 'full_access' }).decision).toBe('denied');
+  });
+});

--- a/tests/access-policy.test.ts
+++ b/tests/access-policy.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -49,7 +49,7 @@ describe('repository access policy', () => {
     const home = controllerHome();
     writeRepositoryAccessPolicy(home, 'repo-test', 'full_access');
     const path = repositoryAccessPolicyPath(home, 'repo-test');
-    Bun.write(path, '{invalid-json');
+    writeFileSync(path, '{invalid-json', 'utf-8');
 
     expect(readRepositoryAccessPolicy(home, 'repo-test').mode).toBe('request');
   });

--- a/tests/runtime/access-mcp-tools.test.ts
+++ b/tests/runtime/access-mcp-tools.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { callAccessTool } from '../../src/cli/mcp/access-tools';
+import { getMcpPolicy } from '../../src/cli/mcp/policy';
+import { exposedControllerToolDefinitions } from '../../src/cli/mcp/toolset';
+import type { MultiRepositoryMcpToolContext } from '../../src/cli/mcp/multi-repository';
+import { ensureControllerHome } from '../../src/cli/repositories/controller-home';
+import { registerRepository } from '../../src/cli/repositories/registry';
+
+const roots: string[] = [];
+
+function fixture() {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'repo-harness-access-mcp-repo-'));
+  const controllerHome = mkdtempSync(join(tmpdir(), 'repo-harness-access-mcp-home-'));
+  roots.push(repoRoot, controllerHome);
+  spawnSync('git', ['init', '-b', 'main'], { cwd: repoRoot, stdio: 'ignore' });
+  writeFileSync(join(repoRoot, 'README.md'), '# fixture\n');
+  spawnSync('git', ['add', 'README.md'], { cwd: repoRoot, stdio: 'ignore' });
+  spawnSync('git', ['-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-m', 'init'], {
+    cwd: repoRoot,
+    stdio: 'ignore',
+  });
+  ensureControllerHome(controllerHome);
+  const repository = registerRepository({
+    path: repoRoot,
+    controllerHome,
+    displayName: 'permission fixture',
+    repoIdOverride: 'repo-permissions',
+  });
+  const ctx = {
+    repoRoot,
+    controllerHome,
+    policy: getMcpPolicy('controller', { repoRoot }),
+    toolset: 'core' as const,
+    enableChatgptBrowser: false,
+    explicitRepository: repository,
+    audit: () => undefined,
+  } as unknown as MultiRepositoryMcpToolContext;
+  return { ctx, repository };
+}
+
+function payload(result: ReturnType<typeof callAccessTool>): Record<string, unknown> {
+  expect(result).toBeTruthy();
+  return result!.structuredContent as Record<string, unknown>;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('repository access MCP tools', () => {
+  test('core toolset exposes get and set tools', () => {
+    const { ctx } = fixture();
+    const names = exposedControllerToolDefinitions(ctx).map((tool) => tool.name);
+    expect(names).toContain('repository_access_get');
+    expect(names).toContain('repository_access_set');
+  });
+
+  test('get returns Request by default', () => {
+    const { ctx, repository } = fixture();
+    const value = payload(callAccessTool(ctx, 'repository_access_get', { repo_id: repository.repoId }));
+    expect(value).toMatchObject({
+      policy: { mode: 'request', updatedBy: 'system' },
+      descriptor: { shortLabel: 'Request' },
+      scope: 'repository',
+      storage: 'controllerHome',
+    });
+  });
+
+  test('Full Access requires explicit strong confirmation', () => {
+    const { ctx, repository } = fixture();
+    const missing = callAccessTool(ctx, 'repository_access_set', {
+      repo_id: repository.repoId,
+      mode: 'full_access',
+      confirm_authorization: true,
+    });
+    expect(missing?.isError).toBe(true);
+    expect(payload(missing)).toMatchObject({
+      error: { code: 'FULL_ACCESS_STRONG_CONFIRMATION_REQUIRED' },
+    });
+
+    const enabled = callAccessTool(ctx, 'repository_access_set', {
+      repo_id: repository.repoId,
+      mode: 'full_access',
+      confirm_authorization: true,
+      confirmation_text: 'enable-full-access',
+    });
+    expect(enabled?.isError).not.toBe(true);
+    expect(payload(enabled)).toMatchObject({
+      policy: { mode: 'full_access', updatedBy: 'user' },
+      descriptor: { shortLabel: 'Full Access' },
+    });
+
+    expect(payload(callAccessTool(ctx, 'repository_access_get', { repo_id: repository.repoId }))).toMatchObject({
+      policy: { mode: 'full_access' },
+    });
+  });
+
+  test('downgrading to Request remains an explicit write action', () => {
+    const { ctx, repository } = fixture();
+    const denied = callAccessTool(ctx, 'repository_access_set', {
+      repo_id: repository.repoId,
+      mode: 'request',
+    });
+    expect(denied?.isError).toBe(true);
+    expect(payload(denied)).toMatchObject({
+      error: { code: 'ACCESS_MODE_AUTHORIZATION_REQUIRED' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add repository-scoped `request` and `full_access` permission modes
- store repository defaults under controllerHome, never in Git
- capture the effective mode in each WorkContract
- allow Full Access only for local repository/workspace effects
- keep remote writes, destructive actions, outside-repository paths, and secrets gated
- expose `repository_access_get` / `repository_access_set` in the core MCP toolset
- require strong confirmation text before enabling Full Access
- return the effective access mode in `rh_work` results
- document storage, safety boundaries, and per-task overrides

## Compatibility

- missing or malformed policy defaults to `request`
- callers that omit access mode retain existing approval behavior
- existing approval and external-effect hard gates remain in force

## Tests added

- access policy persistence and fallback
- Request / Full Access decision matrix
- work routing and access-mode snapshots
- strong confirmation for MCP permission changes
- core toolset exposure

## Verification note

The repository's `Windows smoke` workflow did not reach dependency installation or tests. `actions/checkout@v4` failed on the pre-existing Windows-invalid path `plans/sprints/20260617-Sprint: Harness Engineering Optimization — State, Review, Eval, Delegation.md`. The failure is unrelated to this PR's changed files. The change set was reviewed statically, including the complete PR diff and the existing facade/work-contract call paths.