### PR TITLE
fix(release): make tarball path deterministic

### DIFF
--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -24,18 +24,12 @@ bun run check:public-export
 
 ARTIFACT_DIR="${FORGE_RELEASE_ARTIFACT_DIR:-$ROOT/.ai/harness/artifacts/release}"
 mkdir -p "$ARTIFACT_DIR"
-PACK_JSON="$ARTIFACT_DIR/pack.json"
-echo "[release-readiness] create one reusable tarball"
-npm pack --json --pack-destination "$ARTIFACT_DIR" >"$PACK_JSON"
-TARBALL="$(bun - "$PACK_JSON" <<'JS_EOF'
-const [, , path] = process.argv;
-const value = await Bun.file(path).json();
-const entry = Array.isArray(value) ? value[0] : value;
-if (!entry?.filename) throw new Error('npm pack did not report a filename');
-console.log(entry.filename);
-JS_EOF
-)"
+TARBALL="$(node -e 'const p=require("./package.json"); process.stdout.write(`${p.name.replace(/^@/, "").replace(/\//g, "-")}-${p.version}.tgz`)')"
 TARBALL_PATH="$ARTIFACT_DIR/$TARBALL"
+echo "[release-readiness] create one reusable tarball"
+rm -f "$TARBALL_PATH"
+npm pack --pack-destination "$ARTIFACT_DIR" >/dev/null
+[[ -f "$TARBALL_PATH" ]] || { echo "[release-readiness] ERROR: npm pack did not create $TARBALL_PATH" >&2; exit 1; }
 printf '%s\n' "$TARBALL_PATH" >"$ARTIFACT_DIR/latest-tarball.txt"
 
 echo "[release-readiness] smoke the same tarball"

--- a/tests/release/package-release.test.ts
+++ b/tests/release/package-release.test.ts
@@ -20,7 +20,7 @@ describe("public package release contract", () => {
     });
     expect(pkg.scripts.prepublishOnly).toBeUndefined();
     expect([pkg.scripts["release:rc"], pkg.scripts["release:stable"]]).toEqual(["bash scripts/publish-release-tarball.sh next", "bash scripts/publish-release-tarball.sh latest"]);
-    expect(read("scripts/publish-release-tarball.sh")).toMatch(/NPM_RELEASE_REGISTRY="\$\{NPM_RELEASE_REGISTRY:-https:\/\/registry\.npmjs\.org\/\}"[\s\S]*NPM_RELEASE_BOOTSTRAP[\s\S]*--registry "\$NPM_RELEASE_REGISTRY" --provenance=false/);
+    expect(read("scripts/publish-release-tarball.sh")).toMatch(/NPM_RELEASE_REGISTRY="\$\{NPM_RELEASE_REGISTRY:-https:\/\/registry\.npmjs\.org\/\}"[\s\S]*NPM_RELEASE_BOOTSTRAP[\s\S]*--registry "\$NPM_RELEASE_REGISTRY" --provenance=false/); expect(read("scripts/check-release-readiness.sh")).toMatch(/npm pack --pack-destination "\$ARTIFACT_DIR"[\s\S]*\[\[ -f "\$TARBALL_PATH" \]\]/); expect(read("scripts/check-release-readiness.sh")).not.toContain("npm pack --json");
   });
 
   test("ships maintained public docs and excludes internal reports", () => {


### PR DESCRIPTION
## What changed
- derive the release tarball filename from package name/version instead of npm pack --json output
- assert the expected tarball exists before install smoke
- keep the release contract covered by a regression assertion

## Why
The v1.5.0-rc.1 tag workflow failed on GitHub Linux with npm 11 because npm pack JSON did not expose filename in the shape assumed by the release script. The package itself had already published successfully and the published-release gate passed.

## Validation
- bun test tests/release/package-release.test.ts (5/5)
- governed affected release test (5/5)
- bun install --frozen-lockfile
- npm 11.19.0 + bun run check:release
- tarball install/CLI smoke passed