### PR TITLE
docs(readme): lead with Forge product value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,96 @@
 <a id="english"></a>
 
-<p align="center"><img src="docs/images/forge-banner.svg" alt="Forge — local-first action runtime" width="1280"></p>
-<p align="center"><strong>Local-first action runtime for ChatGPT and AI coding assistants.</strong></p>
-<p align="center"><a href="#english">English</a> · <a href="#zh-cn">简体中文</a> · <a href="docs/README.md">Docs</a> · <a href="docs/forge-plugin-management.md">Plugins</a> · <a href="https://github.com/moretea-labs/forge/releases">Releases</a></p>
+<p align="center"><img src="docs/images/forge-banner.svg" alt="Forge — ChatGPT decides, Forge acts" width="1280"></p>
+<p align="center"><strong>Give ChatGPT real, controlled hands on your computer, code, browser, and services.</strong></p>
+<p align="center"><a href="#english">English</a> · <a href="#zh-cn">简体中文</a> · <a href="docs/README.md">Docs</a> · <a href="docs/operations/features.md">Features</a> · <a href="docs/forge-plugin-management.md">Plugins</a> · <a href="https://github.com/moretea-labs/forge/releases">Releases</a></p>
 <p align="center"><img alt="CI" src="https://github.com/moretea-labs/forge/actions/workflows/ci.yml/badge.svg"> <img alt="Release" src="https://img.shields.io/github/v/release/moretea-labs/forge?include_prereleases&sort=semver"> <img alt="npm next" src="https://img.shields.io/npm/v/%40moretea-labs%2Fforge?tag=next&label=npm%20next"> <img alt="License" src="https://img.shields.io/github/license/moretea-labs/forge"></p>
 
-Forge gives ChatGPT a bounded, auditable way to work with **real local repositories, processes, plugins, and recovery state**. It keeps durable execution facts outside the chat, uses the lightest valid path for small work, and preserves explicit safety boundaries for remote, destructive, secret, and outside-workspace effects.
+**ChatGPT is the controller. Forge is the action layer.** Keep the conversation as your primary workspace, then let Forge perform the parts chat alone cannot: read and write authorized local files, execute commands, work across repositories, operate browsers and macOS, call service plugins, keep long-running work attached, and bring back evidence you can review.
 
-## Why Forge
+For the normal ChatGPT Connector path, Forge does **not** require a separate OpenAI API key or a second per-token model budget. Your existing ChatGPT plan/session limits still apply. Optional Codex, Claude, OpenAI API, or other model providers are separate delegation paths—not a requirement for using Forge.
 
-| Need | Forge behavior |
+## What Forge gives ChatGPT
+
+| Capability | What that means for you |
 | --- | --- |
-| Work on real code | Stable `repoId + checkoutId` identity binds every repository operation to the intended checkout. |
-| Keep small tasks fast | Direct-first execution avoids Plan/Issue/Agent/worktree overhead when the change is already understood. |
-| Run long work once | Process Runtime owns build/test/process lifecycle; status, wait, logs, and cancel attach to the same process. |
-| Work concurrently | Independent repositories run in parallel; worktrees are introduced only when isolation is actually needed. |
-| Trust the result | Focused checks, diffs, receipts, evidence, immutable runtime releases, and Recovery make outcomes reviewable. |
-| Extend safely | Typed external providers install through Forge's pinned catalog and reuse the same authorization/evidence path. |
+| **Your local computer** | Authorize a folder, then let ChatGPT list/read/write/copy/move files, create directories, open documents or Finder, run bounded commands, inspect processes, and manage verified macOS LaunchAgents. |
+| **Real software work** | Inspect and edit repositories, run tests/builds, use Git and worktrees, keep long commands attached, verify results, commit, and clean temporary work. |
+| **Browser + desktop** | Navigate, inspect, click, fill, screenshot, transfer files, and hand off when human interaction is required; Chrome/Vivaldi native attach and macOS desktop actions are supported where available. |
+| **Apple workflows** | Build and inspect iOS projects, work with simulators/devices, and use App Store Connect for apps, builds, TestFlight, review state, and Xcode Cloud workflows. |
+| **Your services** | Typed plugins for GitHub, Gmail, Google Calendar, Google Tasks, Resend, plus independently released Forge providers. |
+| **Automation + recovery** | Long commands stay attached instead of being restarted; scheduled/recurring work can persist outside chat and hand control back to ChatGPT when reasoning is needed. Repository identity, checks, approvals, and recovery facts survive outside the conversation. |
 
-## Quick start
+### Ask for outcomes, not tools
 
-Requirements: Git, Node.js 20.10+, npm, and a writable home directory. Bun 1.0+ is recommended for source development and the full test suite.
+```text
+“Clean up these generated files, run the project checks, commit the fix, and remove the worktree.”
+“Read this authorized folder, reorganize the documents, and open the result in Finder.”
+“Open the web app, test this flow in Chrome, capture evidence, then fix the UI regression.”
+“Summarize today’s inbox, archive obvious promotions, and prepare the important replies.”
+“Check the latest TestFlight build and tell me what blocks release.”
+```
+
+Forge deliberately keeps the tool mechanics below the conversation. You describe the goal; ChatGPT chooses the next action, Forge enforces scope and execution policy, and optional specialist agents can be delegated only when they add value.
+
+## Start in minutes
+
+Requirements: **Git, Node.js 20.10+, npm**, and a writable home directory. Bun 1.0+ is recommended for source development.
 
 ```bash
 npm install -g @moretea-labs/forge@next
-forge --version
 forge setup open --target both
 forge setup next     # repeat until ready
 forge setup close
 forge doctor
 ```
 
-Connect ChatGPT with [Tutorial 2](docs/tutorials/02-connect-chatgpt.md), then adopt a repository:
+Then follow [Install and start](docs/tutorials/01-install-and-start.md) and [Connect ChatGPT](docs/tutorials/02-connect-chatgpt.md). To adopt a project: `forge adopt --repo /path/to/your-project`.
 
-```bash
-forge adopt --repo /path/to/your-project --dry-run
-forge adopt --repo /path/to/your-project
-forge repo list --json
-```
+For a reviewed source checkout: `git clone https://github.com/moretea-labs/forge.git && cd forge && npm ci --ignore-scripts --no-audit --no-fund && npm install -g . --omit=optional --no-audit --no-fund`.
 
-For source development, follow [Install and start](docs/tutorials/01-install-and-start.md) or install the reviewed checkout directly:
+## Built in, and extensible
 
-```bash
-git clone https://github.com/moretea-labs/forge.git && cd forge
-npm ci --ignore-scripts --no-audit --no-fund
-npm install -g . --omit=optional --no-audit --no-fund
-```
+Forge ships typed local/browser/desktop/iOS/GitHub/Gmail/Calendar/Tasks/App Store Connect/Resend capabilities. The public provider catalog currently includes **Forge Desktop Operator**, **Forge Design**, and **Personal Knowledge Assistant**; install with `forge plugin catalog` / `forge plugin install <id>`. See [Features](docs/operations/features.md) and [Plugin Management](docs/forge-plugin-management.md).
 
-## How ChatGPT uses Forge
+## Controlled by design
 
-The normal ChatGPT connector exposes a bounded **19-tool MCP surface**. Five preferred facades—`rh_status`, `rh_access`, `rh_inbox`, `rh_context`, and `rh_work`—cover most orchestration; repository, source/patch, check, Process, plugin-dispatch, and result tools complete the default surface.
+Local read/write grants are explicit and expiring; remote or destructive effects are distinguished from ordinary local work; high-impact actions require stronger confirmation. Full Access reduces repetitive prompts for normal work without removing the hard boundaries around secrets, destructive actions, and outside-workspace access. See [Security](SECURITY.md) and the [Security Model](docs/wiki/Security-Model.md).
 
-```text
-Small task  → inspect → relevant context → Direct Edit → focused check → commit
-Long task   → resolve identity → durable work only if needed → Process/worktree → verify → integrate → clean
-```
-
-<p align="center"><img src="docs/images/forge-controller-flow.svg" alt="Forge canonical runtime flow" width="980"></p>
-
-Ask for the outcome, not the tool: “fix this failing test and commit”, “compare these repositories in parallel”, or “run the build and keep using the same Process”.
-
-## Official providers
-
-| Provider | Purpose | Install |
-| --- | --- | --- |
-| [Forge Desktop Operator](https://github.com/moretea-labs/forge-desktop-operator) | Native macOS desktop automation | `forge plugin install desktop_operator` |
-| [Forge Design](https://github.com/moretea-labs/forge-design) | Repository-native design workspace and `design.md` provider | `forge plugin install design` |
-| [Personal Knowledge Assistant](https://github.com/moretea-labs/personal-knowledge-assistant) | Local-first personal knowledge retrieval, memory, and safe writes | `forge plugin install personal_knowledge` |
-
-See [Plugin Management](docs/forge-plugin-management.md) for trust, distribution, update, and transport boundaries. Investment Decision System remains an independent product rather than a Forge plugin.
-
-## Safety model
-
-Forge distinguishes observation, normal local changes, remote effects, destructive actions, outside-workspace access, and secrets. Full Access reduces repetitive approval for ordinary local work; it does **not** weaken destructive, remote, or secret boundaries. See [Security Model](docs/wiki/Security-Model.md) and [SECURITY.md](SECURITY.md).
-
-## Documentation
-
-- **Start:** [Documentation hub](docs/README.md) · [Wiki](docs/wiki/Home.md) · [Quick Start](docs/wiki/Quick-Start.md) · [Public usage guide](docs/public-usage-guide.md)
-- **Understand:** [Core Concepts](docs/wiki/Core-Concepts.md) · [Architecture](docs/wiki/Architecture.md) · [Work Lifecycle](docs/wiki/Work-Lifecycle.md)
-- **Operate:** [Operations](docs/wiki/Operations.md) · [Troubleshooting](docs/operations/troubleshooting.md) · [Platform support](docs/operations/platform-support.md)
-- **Maintain:** [Contributing](CONTRIBUTING.md) · [Release process](docs/operations/releasing.md) · [Changelog](CHANGELOG.md) · [Support](SUPPORT.md)
-
-**Current release candidate:** `1.5.0-rc.1` on the npm `next` channel. Stable releases use `latest`. Forge is MIT licensed; see [LICENSE](LICENSE), [NOTICE](NOTICE), and [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+**Docs:** [Wiki](docs/wiki/Home.md) · [Support](SUPPORT.md) · [Contributing](CONTRIBUTING.md) · [Changelog](CHANGELOG.md). Current release candidate: `1.5.0-rc.1`; RCs use npm `next`. Stable releases use `latest` after a stable version exists.
 
 ---
 <a id="zh-cn"></a>
 
-<p align="center"><img src="docs/images/forge-banner-cn.svg" alt="Forge——本地优先的行动运行时" width="1280"></p>
-<p align="center"><strong>面向 ChatGPT 与 AI 编程助手的本地优先行动运行时。</strong></p>
-<p align="center"><a href="#english">English</a> · <a href="#zh-cn">简体中文</a> · <a href="docs/README.zh-CN.md">中文文档</a> · <a href="docs/forge-plugin-management.md">插件</a> · <a href="https://github.com/moretea-labs/forge/releases">版本</a></p>
+<p align="center"><img src="docs/images/forge-banner-cn.svg" alt="Forge——ChatGPT 决策，Forge 执行" width="1280"></p>
+<p align="center"><strong>让 ChatGPT 真正、安全地操作你的电脑、代码、浏览器和外部服务。</strong></p>
+<p align="center"><a href="#english">English</a> · <a href="#zh-cn">简体中文</a> · <a href="docs/README.zh-CN.md">中文文档</a> · <a href="docs/operations/features.zh-CN.md">功能</a> · <a href="docs/forge-plugin-management.md">插件</a></p>
 
-Forge 让 ChatGPT 在**真实本地仓库、进程、插件与恢复状态**上执行有边界、可审查的工作。小任务默认走最短路径；长任务复用同一个 Process；远程、破坏性、密钥和工作区外访问继续保持明确安全边界。
+**ChatGPT 是主控，Forge 是行动层。** 你仍然把 ChatGPT 对话当作主要工作入口，但 Forge 能把“聊天”扩展成真实执行：读写授权的本机目录、运行命令、修改代码和 Git、操作浏览器与 macOS、调用邮件/日历/Apple 等插件，并把长任务状态和验证证据保存在聊天之外。
 
-## 核心能力
+正常的 ChatGPT Connector 路径**不要求你再为 Forge 配一份 OpenAI API Key，也不需要额外准备一套按 token 计费的模型预算**；仍然受你自己的 ChatGPT 套餐和会话限制。Codex、Claude、OpenAI API 等只是可选委派能力，不是 Forge 的前置条件。
 
-- **Direct-first**：范围明确的小修改不因调查自动创建 Plan、Issue、Agent 或 worktree。
-- **真实并发**：不同仓库可并行；需要隔离时再建立 worktree；同一 checkout 保持单写者。
-- **可恢复执行**：build/test 只启动一次，后续 status/wait/log/cancel 连接同一个 Process。
-- **明确身份**：`repoId + checkoutId` 防止一个会话误操作另一个 checkout。
-- **可验证结果**：diff、focused check、receipt、evidence、不可变 Runtime release 与 Recovery 都可追溯。
-- **类型化插件**：官方 Provider 从固定版本目录安装，并复用 Forge 的授权、资源声明与证据链。
+## Forge 能让 ChatGPT 做什么
+
+| 能力 | 用户真正得到什么 |
+| --- | --- |
+| **操作本机** | 授权一个目录后，可列出/读取/写入/复制/移动文件，创建目录，打开文档或 Finder，执行受控命令，查看进程并管理经过身份校验的 macOS LaunchAgent。 |
+| **完成真实开发任务** | 读取和修改仓库、运行测试/构建、操作 Git/worktree、持续跟踪长命令、验证结果、提交并清理临时工作区。 |
+| **浏览器与桌面** | 页面导航、读取、点击、填写、截图、文件传输；需要人工时再 handoff；可使用 Chrome/Vivaldi 原生 attach 与 macOS 桌面能力。 |
+| **Apple 工作流** | iOS 构建、模拟器/设备，以及 App Store Connect 的版本、构建、TestFlight、审核状态和 Xcode Cloud。 |
+| **连接你的服务** | GitHub、Gmail、Google Calendar、Google Tasks、Resend，以及独立发布的 Forge Provider。 |
+| **自动化与可恢复执行** | 长命令不会因为聊天继续而重跑；定时/周期工作可以持久化，在需要判断时再交回 ChatGPT。仓库身份、检查、授权与恢复状态也不只存在于聊天上下文里。 |
+
+```text
+“把这个 bug 修好，跑完测试，提交，然后把临时 worktree 清掉。”
+“读取我授权的这个目录，整理文件，并在 Finder 里打开结果。”
+“在 Chrome 里把这个流程走一遍，截图核对，然后修 UI。”
+“汇总今天邮件，把明显广告归档，重要邮件整理给我。”
+“看最新 TestFlight 构建，告诉我离发布还差什么。”
+```
 
 ## 快速开始
+
+需要 **Git、Node.js 20.10+、npm**；源码开发建议 Bun 1.0+。
 
 ```bash
 npm install -g @moretea-labs/forge@next
@@ -111,22 +100,10 @@ forge setup close
 forge doctor
 ```
 
-接入仓库：
+继续阅读[安装与启动](docs/tutorials/01-install-and-start.zh-CN.md)和[连接 ChatGPT](docs/tutorials/02-connect-chatgpt.zh-CN.md)。源码安装：`git clone https://github.com/moretea-labs/forge.git && cd forge && npm ci --ignore-scripts --no-audit --no-fund && npm install -g . --omit=optional --no-audit --no-fund`。
 
-```bash
-forge adopt --repo /path/to/your-project --dry-run
-forge adopt --repo /path/to/your-project
-forge repo list --json
-```
+Forge 内置本机、Browser、Desktop、iOS、GitHub、Gmail、Calendar、Tasks、App Store Connect、Resend 等类型化能力；公开 Provider 目录还有 **Forge Desktop Operator / Forge Design / Personal Knowledge Assistant**。详见[功能清单](docs/operations/features.zh-CN.md)与[插件管理](docs/forge-plugin-management.md)。
 
-普通 ChatGPT Connector 默认收敛为 **19 个 MCP 工具**，其中 `rh_status`、`rh_access`、`rh_inbox`、`rh_context`、`rh_work` 五个 facade 覆盖主要编排。正常使用时直接描述目标，不需要自己挑工具。
+安全上，普通本地修改、远程影响、破坏性操作、密钥和工作区外访问是不同边界；Full Access 不会取消高风险确认。详见[安全说明](SECURITY.md)和[安全模型](docs/wiki/Security-Model.md)。
 
-## 官方 Provider
-
-`forge plugin catalog` 可查看当前目录；官方 Provider 包括 [Forge Desktop Operator](https://github.com/moretea-labs/forge-desktop-operator)、[Forge Design](https://github.com/moretea-labs/forge-design) 与 [Personal Knowledge Assistant](https://github.com/moretea-labs/personal-knowledge-assistant)。详见[插件管理](docs/forge-plugin-management.md)。
-
-## 文档与维护
-
-[中文文档中心](docs/README.zh-CN.md) · [安装教程](docs/tutorials/01-install-and-start.zh-CN.md) · [公开使用指南](docs/public-usage-guide.zh-CN.md) · [架构](docs/wiki/Architecture.md) · [故障排查](docs/operations/troubleshooting.zh-CN.md) · [贡献](CONTRIBUTING.md) · [安全](SECURITY.md)
-
-**当前候选版本：** `1.5.0-rc.1`，npm 使用 `next`；稳定版使用 `latest`。项目采用 [MIT License](LICENSE)。
+**文档：** [Wiki](docs/wiki/Home.md) · [支持](SUPPORT.md) · [贡献](CONTRIBUTING.md) · [更新日志](CHANGELOG.md)。当前 RC 为 `1.5.0-rc.1`，RC 的 npm 使用 `next`；首个稳定版发布后稳定通道使用 `latest`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,26 +1,48 @@
 # Forge
 
-<p align="center"><img src="docs/images/forge-banner-cn.svg" alt="Forge——本地优先的行动运行时" width="1280"></p>
-<p align="center"><strong>面向 ChatGPT 与 AI 编程助手的本地优先行动运行时。</strong></p>
-<p align="center"><a href="README.md#english">English</a> · <a href="README.md#zh-cn">仓库首页中文</a> · <a href="docs/README.zh-CN.md">中文文档</a> · <a href="https://github.com/moretea-labs/forge/releases">版本发布</a></p>
+<p align="center"><img src="docs/images/forge-banner-cn.svg" alt="Forge——ChatGPT 决策，Forge 执行" width="1280"></p>
+<p align="center"><strong>让 ChatGPT 真正、安全地操作你的电脑、代码、浏览器和外部服务。</strong></p>
+<p align="center"><a href="https://github.com/moretea-labs/forge#english">English</a> · <a href="https://github.com/moretea-labs/forge#zh-cn">仓库首页中文</a> · <a href="docs/README.zh-CN.md">中文文档</a> · <a href="docs/operations/features.zh-CN.md">功能清单</a> · <a href="https://github.com/moretea-labs/forge/releases">版本发布</a></p>
 <p align="center"><img alt="CI" src="https://github.com/moretea-labs/forge/actions/workflows/ci.yml/badge.svg"> <img alt="Release" src="https://img.shields.io/github/v/release/moretea-labs/forge?include_prereleases&sort=semver"> <img alt="npm next" src="https://img.shields.io/npm/v/%40moretea-labs%2Fforge?tag=next&label=npm%20next"> <img alt="License" src="https://img.shields.io/github/license/moretea-labs/forge"></p>
 
-Forge 让 ChatGPT 在**真实本地仓库、进程、插件和恢复状态**上执行有边界、可审查的工作。它把 Git、Process、检查和发布证据保存在聊天之外，小任务走最短路径，长任务复用同一个执行生命周期。
+**ChatGPT 是主控，Forge 是行动层。** ChatGPT 负责理解目标、判断下一步和与你沟通；Forge 负责把这些决定安全地落到真实世界：本机文件、命令、仓库、浏览器、macOS、Apple 开发流程以及你的外部服务。
 
-## 为什么使用 Forge
+正常的 ChatGPT Connector 路径**不要求单独配置 OpenAI API Key，也不需要额外准备一套按 token 计费的模型预算**；仍受你自己的 ChatGPT 套餐和会话限制。Codex、Claude、OpenAI API 或其他模型只是可选的委派/自动化后端，不是使用 Forge 的前置条件。
 
-| 需求 | Forge 的处理方式 |
+## 为什么这和普通 Coding Agent 不一样
+
+- **对话就是主工作台**：不用切到另一个 Agent 产品里重新解释上下文；ChatGPT 直接做主控。
+- **不只会写代码**：同一个对话可以处理目录文件、命令、浏览器、桌面、邮件、日历、GitHub、iOS 与 App Store Connect。
+- **真实执行状态在聊天之外**：长命令、检查、仓库身份、授权和恢复状态可以继续接上；定时/周期任务也可以持久化，在需要判断时再交回 ChatGPT。
+- **需要时才委派 Agent**：明确的小任务直接完成；Codex/Claude 等只在确实有价值时作为执行者加入。
+- **权限不是全有或全无**：本机目录授权可过期；远程、破坏性、密钥和工作区外访问有独立边界。
+
+## 你可以直接这样说
+
+```text
+“把这个 bug 修好，跑完测试，提交，然后把临时 worktree 清掉。”
+“读取我授权的这个目录，整理文件，并在 Finder 里打开结果。”
+“在 Chrome 里把这个流程走一遍，截图核对，然后修 UI。”
+“汇总今天邮件，把明显广告归档，重要邮件整理给我。”
+“看最新 TestFlight 构建，告诉我离发布还差什么。”
+```
+
+## 现在能做什么
+
+| 领域 | 典型能力 |
 | --- | --- |
-| 操作真实代码 | 使用稳定的 `repoId + checkoutId` 绑定目标仓库和 checkout。 |
-| 小任务不要重流程 | Direct-first；仅调查不会自动创建 Plan、Issue、Agent 或 worktree。 |
-| 长命令不要重复跑 | Process Runtime 只启动一次，后续 status/wait/log/cancel 连接同一个 Process。 |
-| 多仓库并发工作 | 不同仓库可并行；真正需要隔离时才建立 worktree。 |
-| 结果能够复核 | diff、focused check、receipt、evidence、不可变 Runtime release 与 Recovery 都可追溯。 |
-| 安全扩展能力 | 官方 Provider 从固定版本目录安装，复用 Forge 的授权、资源声明和证据链。 |
+| **本机文件与命令** | 授权目录后列出/读取/写入/复制/移动文件、创建目录、打开文件/Finder、typed command、校验过的项目脚本、系统与进程诊断、macOS LaunchAgent 管理。 |
+| **软件开发** | 多仓库读取与修改、Git、patch、测试/构建、长进程、worktree、验证、提交与清理；支持 Direct-first 的快速任务路径。 |
+| **Browser / Desktop** | 页面导航、读取、选择器、点击、填写、截图、文件传输、人工 handoff；Chrome/Vivaldi 原生 attach；macOS Desktop 与可安装的 Desktop Operator。 |
+| **Apple** | iOS 项目/模拟器/设备；App Store Connect 应用、版本、Build、TestFlight、审核信息和 Xcode Cloud workflow。 |
+| **生产力服务** | GitHub Issue/Project、Gmail、Google Calendar、Google Tasks、Resend Email。 |
+| **扩展能力** | 官方目录中的 Forge Design、Personal Knowledge Assistant、Desktop Operator；外部 Provider 仍复用 Forge 的权限和执行边界。 |
+
+> 具体能力依赖操作系统、已安装 Provider、账号授权和目标服务配置。Forge 不会因为 README 写了某项能力就绕过平台权限或服务认证。
 
 ## 快速开始
 
-需要 Git、Node.js 20.10+、npm 和可写用户目录。源码开发建议安装 Bun 1.0+。
+需要 **Git、Node.js 20.10+、npm** 和可写用户目录；源码开发建议 Bun 1.0+。
 
 ```bash
 npm install -g @moretea-labs/forge@next
@@ -31,7 +53,13 @@ forge setup close
 forge doctor
 ```
 
-接入仓库：
+接着阅读：
+
+1. [安装与启动](docs/tutorials/01-install-and-start.zh-CN.md)
+2. [连接 ChatGPT](docs/tutorials/02-connect-chatgpt.zh-CN.md)
+3. [完成第一个仓库任务](docs/tutorials/03-first-repository-task.zh-CN.md)
+
+接入项目：
 
 ```bash
 forge adopt --repo /path/to/your-project --dry-run
@@ -39,7 +67,7 @@ forge adopt --repo /path/to/your-project
 forge repo list --json
 ```
 
-接下来按[连接 ChatGPT](docs/tutorials/02-connect-chatgpt.zh-CN.md)和[完成第一个仓库任务](docs/tutorials/03-first-repository-task.zh-CN.md)继续。源码开发可使用：
+从源码安装已审查 checkout：
 
 ```bash
 git clone https://github.com/moretea-labs/forge.git && cd forge
@@ -47,38 +75,16 @@ npm ci --ignore-scripts --no-audit --no-fund
 npm install -g . --omit=optional --no-audit --no-fund
 ```
 
-## ChatGPT 如何使用 Forge
+## 插件与能力
 
-普通 ChatGPT Connector 默认是 **19 个 MCP 工具**。五个主要 facade——`rh_status`、`rh_access`、`rh_inbox`、`rh_context`、`rh_work`——覆盖日常编排，其余默认工具负责仓库、源码/补丁、check、Process、插件分发和结果读取。
+Forge 内置本机、Browser、Desktop、iOS、GitHub、Gmail、Calendar、Tasks、App Store Connect、Resend 等类型化插件；公开 Provider 目录还提供 **Forge Desktop Operator**、**Forge Design**、**Personal Knowledge Assistant**。运行 `forge plugin catalog` 查看当前固定版本目录，详见[插件管理](docs/forge-plugin-management.md)和[功能清单](docs/operations/features.zh-CN.md)。
 
-```text
-小任务 → 状态/上下文 → Direct Edit → focused check → commit
-长任务 → 确定身份 → 确有需要才建 durable work → Process/worktree → verify → integrate → clean
-```
+## 安全不是宣传词
 
-<p align="center"><img src="docs/images/forge-controller-flow.svg" alt="Forge Canonical Runtime 流程" width="980"></p>
+Forge 把读取、普通本地写入、远程操作、破坏性操作、工作区外访问和密钥访问分开处理。本机目录采用显式授权；高风险行为需要更强确认。Full Access 只减少普通工作的重复提示，不会取消这些硬边界。详见 [SECURITY.md](SECURITY.md) 和[安全模型](docs/wiki/Security-Model.md)。
 
-正常使用时直接描述目标即可，不需要自己挑工具。
+## 文档与项目
 
-## 官方 Provider
+[中文文档中心](docs/README.zh-CN.md) · [Wiki](docs/wiki/Home.md) · [SUPPORT.md](SUPPORT.md) · [CONTRIBUTING.md](CONTRIBUTING.md) · [CHANGELOG.md](CHANGELOG.md)
 
-| Provider | 用途 | 安装 |
-| --- | --- | --- |
-| [Forge Desktop Operator](https://github.com/moretea-labs/forge-desktop-operator) | macOS 原生桌面操作 | `forge plugin install desktop_operator` |
-| [Forge Design](https://github.com/moretea-labs/forge-design) | 仓库原生设计工作区和 `design.md` | `forge plugin install design` |
-| [Personal Knowledge Assistant](https://github.com/moretea-labs/personal-knowledge-assistant) | 本地优先个人知识检索、记忆与安全写入 | `forge plugin install personal_knowledge` |
-
-Forge 不扫描用户本机 sibling 仓库，也不允许模型临时提供任意 executable。完整边界见[插件管理](docs/forge-plugin-management.md)。Investment Decision System 保持独立产品，不进入 Forge 官方插件目录。
-
-## 安全模型
-
-Forge 区分读取、普通本地修改、远程影响、破坏性操作、工作区外访问和密钥访问。Full Access 只减少普通本地工作的重复授权，不会削弱 destructive、remote 或 secret 边界。详见[安全模型](docs/wiki/Security-Model.md)和 [SECURITY.md](SECURITY.md)。
-
-## 文档
-
-- **开始使用：** [中文文档中心](docs/README.zh-CN.md) · [安装](docs/tutorials/01-install-and-start.zh-CN.md) · [公开使用指南](docs/public-usage-guide.zh-CN.md)
-- **理解系统：** [Wiki](docs/wiki/Home.md) · [核心概念](docs/wiki/Core-Concepts.md) · [架构](docs/wiki/Architecture.md) · [工作生命周期](docs/wiki/Work-Lifecycle.md)
-- **运维维护：** [故障排查](docs/operations/troubleshooting.zh-CN.md) · [平台支持](docs/operations/platform-support.zh-CN.md) · [发布流程](docs/operations/releasing.zh-CN.md)
-- **参与项目：** [贡献](CONTRIBUTING.md) · [安全](SECURITY.md) · [支持](SUPPORT.md) · [版本记录](CHANGELOG.md)
-
-**当前候选版本：** `1.5.0-rc.1`，npm 使用 `next`；稳定版本使用 `latest`。项目采用 [MIT License](LICENSE)。
+当前 Release Candidate 是 `1.5.0-rc.1`，RC 的 npm 使用 `next`；首个稳定版发布后稳定通道使用 `latest`。

--- a/assets/branding/README.md
+++ b/assets/branding/README.md
@@ -2,9 +2,11 @@
 
 These files are the maintained, public-safe, first-party branding assets for **Forge**.
 
-- `docs/images/forge-banner.svg`: English README and social-share banner.
-- `docs/images/forge-banner-cn.svg`: Simplified Chinese README and social-share banner.
+- `docs/images/forge-banner.svg`: English product hero / social-share banner — **ChatGPT decides. Forge acts.**
+- `docs/images/forge-banner-cn.svg`: Simplified Chinese product hero / social-share banner — **ChatGPT 决策，Forge 执行。**
 - `docs/images/forge-controller-flow.svg`: current Forge controller and Runtime architecture diagram.
 - `forge-controller-flow.mmd`: editable Mermaid source for the architecture diagram.
+
+The README hero should communicate the product before the architecture: ChatGPT is the controller; Forge is the controlled action layer for local files, commands, code, browser/desktop, Apple workflows, and typed plugins.
 
 Use **Forge** in prose and lowercase `forge` only for commands, package paths, protocol identifiers, state paths, filenames, or code symbols. Do not add previous-product branding, compatibility messaging, third-party logos, trademarks, or stock illustrations.

--- a/docs/images/forge-banner-cn.svg
+++ b/docs/images/forge-banner-cn.svg
@@ -1,1 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="320" viewBox="0 0 1280 320" role="img" aria-labelledby="title desc"><title id="title">Forge</title><desc id="desc">Forge 本地优先行动运行时</desc><rect width="1280" height="320" rx="36" fill="#111827"/><path d="M136 224V96h190v38H180v22h126v36H180v32h146v38H136Z" fill="#f9fafb"/><text x="376" y="190" fill="#f9fafb" font-family="system-ui, sans-serif" font-size="112" font-weight="700">Forge</text><text x="382" y="238" fill="#d1d5db" font-family="system-ui, sans-serif" font-size="28">本地优先行动运行时</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="420" viewBox="0 0 1280 420" role="img" aria-labelledby="title desc">
+  <title id="title">Forge</title><desc id="desc">Forge 让 ChatGPT 在明确权限边界内操作本机文件、命令、代码、浏览器、Apple 工作流与插件。</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0d12"/><stop offset="1" stop-color="#171b24"/></linearGradient>
+    <linearGradient id="forge" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffb15c"/><stop offset="1" stop-color="#ff6b35"/></linearGradient>
+    <radialGradient id="glow" cx="0.18" cy="0.5" r="0.55"><stop offset="0" stop-color="#ff7a3d" stop-opacity="0.22"/><stop offset="1" stop-color="#ff7a3d" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="1280" height="420" rx="38" fill="url(#bg)"/><rect width="1280" height="420" rx="38" fill="url(#glow)"/>
+  <g opacity="0.12" stroke="#ffffff"><path d="M0 70H1280M0 140H1280M0 210H1280M0 280H1280M0 350H1280"/><path d="M160 0V420M320 0V420M480 0V420M640 0V420M800 0V420M960 0V420M1120 0V420"/></g>
+  <rect x="74" y="75" width="126" height="126" rx="28" fill="url(#forge)"/>
+  <path d="M108 170V106h67v18h-46v10h39v17h-39v19z" fill="#111318"/>
+  <text x="74" y="258" fill="#f8fafc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="72" font-weight="760">Forge</text>
+  <text x="74" y="305" fill="#ff9b55" font-family="ui-sans-serif,system-ui,sans-serif" font-size="24" font-weight="700" letter-spacing="1">CHATGPT 决策，FORGE 执行</text>
+  <text x="74" y="344" fill="#b8c0cc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="22">连接你的电脑、代码、浏览器与外部服务。</text>
+  <g font-family="ui-sans-serif,system-ui,sans-serif">
+    <rect x="700" y="78" width="190" height="72" rx="18" fill="#202631" stroke="#3b4556"/><text x="795" y="107" text-anchor="middle" fill="#9ba7b8" font-size="13" font-weight="700" letter-spacing="1.5">主控</text><text x="795" y="134" text-anchor="middle" fill="#f8fafc" font-size="22" font-weight="700">ChatGPT</text>
+    <path d="M895 114H945" stroke="#ff8a45" stroke-width="3"/><path d="M936 106l12 8-12 8" fill="none" stroke="#ff8a45" stroke-width="3"/>
+    <rect x="955" y="78" width="250" height="72" rx="18" fill="#27251f" stroke="#a65c2c"/><text x="1080" y="107" text-anchor="middle" fill="#ff9b55" font-size="13" font-weight="700" letter-spacing="1.5">行动层</text><text x="1080" y="134" text-anchor="middle" fill="#f8fafc" font-size="22" font-weight="700">Forge</text>
+    <g fill="#151a22" stroke="#343d4c">
+      <rect x="700" y="188" width="150" height="58" rx="16"/><rect x="866" y="188" width="150" height="58" rx="16"/><rect x="1032" y="188" width="173" height="58" rx="16"/>
+      <rect x="700" y="262" width="150" height="58" rx="16"/><rect x="866" y="262" width="150" height="58" rx="16"/><rect x="1032" y="262" width="173" height="58" rx="16"/>
+    </g>
+    <g fill="#e7ebf0" font-size="17" font-weight="650" text-anchor="middle"><text x="775" y="224">本机文件</text><text x="941" y="224">执行命令</text><text x="1118" y="224">Git 与代码</text><text x="775" y="298">浏览器</text><text x="941" y="298">Apple</text><text x="1118" y="298">插件</text></g>
+    <text x="700" y="363" fill="#8e99aa" font-size="15">明确权限 · 可恢复执行 · 可审查证据</text>
+  </g>
+</svg>

--- a/docs/images/forge-banner.svg
+++ b/docs/images/forge-banner.svg
@@ -1,1 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="320" viewBox="0 0 1280 320" role="img" aria-labelledby="title desc"><title id="title">Forge</title><desc id="desc">Forge local-first action runtime</desc><rect width="1280" height="320" rx="36" fill="#111827"/><path d="M136 224V96h190v38H180v22h126v36H180v32h146v38H136Z" fill="#f9fafb"/><text x="376" y="190" fill="#f9fafb" font-family="system-ui, sans-serif" font-size="112" font-weight="700">Forge</text><text x="382" y="238" fill="#d1d5db" font-family="system-ui, sans-serif" font-size="28">local-first action runtime</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="420" viewBox="0 0 1280 420" role="img" aria-labelledby="title desc">
+  <title id="title">Forge</title><desc id="desc">Forge gives ChatGPT a controlled action layer for local files, commands, code, browsers, Apple workflows, and plugins.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0b0d12"/><stop offset="1" stop-color="#171b24"/></linearGradient>
+    <linearGradient id="forge" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffb15c"/><stop offset="1" stop-color="#ff6b35"/></linearGradient>
+    <radialGradient id="glow" cx="0.18" cy="0.5" r="0.55"><stop offset="0" stop-color="#ff7a3d" stop-opacity="0.22"/><stop offset="1" stop-color="#ff7a3d" stop-opacity="0"/></radialGradient>
+  </defs>
+  <rect width="1280" height="420" rx="38" fill="url(#bg)"/><rect width="1280" height="420" rx="38" fill="url(#glow)"/>
+  <g opacity="0.12" stroke="#ffffff"><path d="M0 70H1280M0 140H1280M0 210H1280M0 280H1280M0 350H1280"/><path d="M160 0V420M320 0V420M480 0V420M640 0V420M800 0V420M960 0V420M1120 0V420"/></g>
+  <rect x="74" y="75" width="126" height="126" rx="28" fill="url(#forge)"/>
+  <path d="M108 170V106h67v18h-46v10h39v17h-39v19z" fill="#111318"/>
+  <text x="74" y="258" fill="#f8fafc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="72" font-weight="760">Forge</text>
+  <text x="74" y="305" fill="#ff9b55" font-family="ui-sans-serif,system-ui,sans-serif" font-size="24" font-weight="700" letter-spacing="1">CHATGPT DECIDES. FORGE ACTS.</text>
+  <text x="74" y="344" fill="#b8c0cc" font-family="ui-sans-serif,system-ui,sans-serif" font-size="22">A local-first action layer for your computer, code &amp; services.</text>
+  <g font-family="ui-sans-serif,system-ui,sans-serif">
+    <rect x="700" y="78" width="190" height="72" rx="18" fill="#202631" stroke="#3b4556"/><text x="795" y="107" text-anchor="middle" fill="#9ba7b8" font-size="13" font-weight="700" letter-spacing="1.5">CONTROLLER</text><text x="795" y="134" text-anchor="middle" fill="#f8fafc" font-size="22" font-weight="700">ChatGPT</text>
+    <path d="M895 114H945" stroke="#ff8a45" stroke-width="3"/><path d="M936 106l12 8-12 8" fill="none" stroke="#ff8a45" stroke-width="3"/>
+    <rect x="955" y="78" width="250" height="72" rx="18" fill="#27251f" stroke="#a65c2c"/><text x="1080" y="107" text-anchor="middle" fill="#ff9b55" font-size="13" font-weight="700" letter-spacing="1.5">ACTION LAYER</text><text x="1080" y="134" text-anchor="middle" fill="#f8fafc" font-size="22" font-weight="700">Forge</text>
+    <g fill="#151a22" stroke="#343d4c">
+      <rect x="700" y="188" width="150" height="58" rx="16"/><rect x="866" y="188" width="150" height="58" rx="16"/><rect x="1032" y="188" width="173" height="58" rx="16"/>
+      <rect x="700" y="262" width="150" height="58" rx="16"/><rect x="866" y="262" width="150" height="58" rx="16"/><rect x="1032" y="262" width="173" height="58" rx="16"/>
+    </g>
+    <g fill="#e7ebf0" font-size="17" font-weight="650" text-anchor="middle"><text x="775" y="224">LOCAL FILES</text><text x="941" y="224">COMMANDS</text><text x="1118" y="224">GIT &amp; CODE</text><text x="775" y="298">BROWSER</text><text x="941" y="298">APPLE</text><text x="1118" y="298">PLUGINS</text></g>
+    <text x="700" y="363" fill="#8e99aa" font-size="15">Bounded permissions · durable execution · reviewable evidence</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- reposition README as a product landing page with ChatGPT as the primary controller
- promote real local file/command/browser/desktop/Apple/service capabilities and optional delegation
- clarify normal ChatGPT Connector usage does not require a separate OpenAI API key while ChatGPT plan limits still apply
- keep English/Chinese switching on the repository README via anchors and refresh the bilingual brand hero

## Verification
- package:check:public-docs
- package:check:open-source-surface
- package:check:package-identity
- README relative link validation
- SVG XML parse + macOS Quick Look render

No npm publish, version bump, tag, or release workflow change.