### PR TITLE
feat(recovery): add controller-scoped stable baseline gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "check:main": "bun scripts/run-governed-gate.ts main",
     "check:ci": "bun run check:main",
     "check:release": "bun scripts/run-governed-gate.ts release",
+    "check:stable-baseline": "bun scripts/check-stable-baseline.ts",
     "check:release-surface": "bash scripts/check-public-release-surface.sh",
     "check:release-readiness": "bash scripts/check-release-readiness.sh",
     "check:open-source-surface": "bash scripts/check-open-source-tracked-surface.sh",
@@ -143,10 +144,10 @@
   "devDependencies": {
     "@colbymchenry/codegraph": "1.0.1",
     "@types/bun": "latest",
-    "@types/cors": "^2.8.17",
-    "@types/express": "^5.0.0",
-    "@types/react": "^19.2.0",
-    "@types/react-dom": "^19.2.0",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.6",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^5.2.0",
     "vite": "^7.3.0"
   },
@@ -156,7 +157,7 @@
     "express": "^5.2.1",
     "playwright": "^1.54.1",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.8",
     "typescript": "^6.0.3"
   },
   "packageManager": "npm@10.0.0",

--- a/scripts/check-stable-baseline.ts
+++ b/scripts/check-stable-baseline.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { createHash } from 'crypto';
-import { existsSync, mkdirSync, renameSync, writeFileSync } from 'fs';
-import { join, resolve } from 'path';
+import { mkdirSync, renameSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
 import { resolveControllerHome } from '../src/cli/repositories/controller-home';
 import { recoveryConnectorDescriptor, verifyRecoveryConnector } from '../src/cli/commands/recovery';
 import { loadRecoveryConfig, verifyStableRuntime } from '../src/runtime/standalone-recovery/core';
@@ -27,12 +27,8 @@ function argValue(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-function stableJson(value: unknown): string {
-  return JSON.stringify(value, Object.keys(value as Record<string, unknown>).sort());
-}
-
 function atomicJson(path: string, value: unknown): void {
-  mkdirSync(resolve(path, '..'), { recursive: true, mode: 0o700 });
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const temporary = `${path}.${process.pid}.tmp`;
   writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
   renameSync(temporary, path);
@@ -58,16 +54,18 @@ export async function checkStableBaseline(controllerHomeInput?: string): Promise
   const identity = {
     schemaVersion: 1,
     controllerHome,
-    runtimeInstanceId: runtime.runtimeInstanceId,
+    runtimeInstanceId: runtime.snapshot?.runtimeInstanceId,
     runtimeRelease: runtimeVerify.releases.active?.revision,
     runtimeManifest: runtimeVerify.releases.active?.manifestSha256,
+    runtimeToolSurfaceFingerprint: runtime.snapshot?.toolSurfaceFingerprint,
+    runtimeEndpoint: runtime.snapshot?.endpoint,
     recoveryRelease: connector.currentRelease,
     recoveryUrl: connector.url,
     runtimeReady: runtime.ready,
     runtimeVerifyOk: runtimeVerify.ok,
     connectorVerifyOk: connectorVerify.ok,
   };
-  const receiptId = createHash('sha256').update(stableJson(identity)).digest('hex');
+  const receiptId = createHash('sha256').update(JSON.stringify(identity)).digest('hex');
   const receipt: BaselineReceipt = {
     schemaVersion: 1,
     status: blockers.length === 0 ? 'passed' : 'failed',

--- a/scripts/check-stable-baseline.ts
+++ b/scripts/check-stable-baseline.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { resolveControllerHome } from '../src/cli/repositories/controller-home';
+import { recoveryConnectorDescriptor, verifyRecoveryConnector } from '../src/cli/commands/recovery';
+import { loadRecoveryConfig, verifyStableRuntime } from '../src/runtime/standalone-recovery/core';
+import { observeRuntimeStatus } from '../src/runtime/root/status';
+
+interface BaselineReceipt {
+  schemaVersion: 1;
+  status: 'passed' | 'failed';
+  controllerHome: string;
+  observedAt: string;
+  runtime: ReturnType<typeof observeRuntimeStatus>;
+  recovery: {
+    connector: ReturnType<typeof recoveryConnectorDescriptor>;
+    runtimeVerify: Awaited<ReturnType<typeof verifyStableRuntime>>;
+    connectorVerify: Awaited<ReturnType<typeof verifyRecoveryConnector>>;
+  };
+  blockers: string[];
+  receiptId: string;
+}
+
+function argValue(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value, Object.keys(value as Record<string, unknown>).sort());
+}
+
+function atomicJson(path: string, value: unknown): void {
+  mkdirSync(resolve(path, '..'), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  renameSync(temporary, path);
+}
+
+export async function checkStableBaseline(controllerHomeInput?: string): Promise<BaselineReceipt> {
+  const controllerHome = resolveControllerHome(controllerHomeInput);
+  const config = loadRecoveryConfig(controllerHome);
+  const runtime = observeRuntimeStatus(controllerHome);
+  const connector = recoveryConnectorDescriptor(controllerHome);
+  const runtimeVerify = await verifyStableRuntime(config);
+  const connectorVerify = await verifyRecoveryConnector(controllerHome);
+  const blockers: string[] = [];
+
+  if (!runtime.running || !runtime.ready) blockers.push(`runtime_not_ready:${runtime.reasonCodes.join(',') || 'unknown'}`);
+  if (!runtimeVerify.ok) blockers.push('recovery_runtime_verify_failed');
+  if (!runtimeVerify.releases.coherent) blockers.push('runtime_release_not_coherent');
+  if (!connector.readyForChatGPT) blockers.push(...connector.warnings.map((warning) => `recovery_connector:${warning}`));
+  if (!connectorVerify.ok) blockers.push(...connectorVerify.failures.map((failure) => `recovery_connector_verify:${failure}`));
+  if (!connector.currentRelease) blockers.push('recovery_release_missing');
+
+  const observedAt = new Date().toISOString();
+  const identity = {
+    schemaVersion: 1,
+    controllerHome,
+    runtimeInstanceId: runtime.runtimeInstanceId,
+    runtimeRelease: runtimeVerify.releases.active?.revision,
+    runtimeManifest: runtimeVerify.releases.active?.manifestSha256,
+    recoveryRelease: connector.currentRelease,
+    recoveryUrl: connector.url,
+    runtimeReady: runtime.ready,
+    runtimeVerifyOk: runtimeVerify.ok,
+    connectorVerifyOk: connectorVerify.ok,
+  };
+  const receiptId = createHash('sha256').update(stableJson(identity)).digest('hex');
+  const receipt: BaselineReceipt = {
+    schemaVersion: 1,
+    status: blockers.length === 0 ? 'passed' : 'failed',
+    controllerHome,
+    observedAt,
+    runtime,
+    recovery: { connector, runtimeVerify, connectorVerify },
+    blockers,
+    receiptId,
+  };
+
+  const root = join(controllerHome, 'recovery', 'stable-baseline');
+  atomicJson(join(root, `${receiptId}.json`), receipt);
+  atomicJson(join(root, 'latest.json'), receipt);
+  return receipt;
+}
+
+if (import.meta.main) {
+  const explicit = argValue('--controller-home');
+  if (process.argv.includes('--controller-home') && !explicit) throw new Error('STABLE_BASELINE_CONTROLLER_HOME_REQUIRED');
+  const receipt = await checkStableBaseline(explicit);
+  process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
+  if (receipt.status !== 'passed') process.exitCode = 1;
+}


### PR DESCRIPTION
## Purpose

Second stabilization slice after #142. This introduces the operational acceptance gate required by #141 and the Recovery-stable control-plane plan.

`check:release` remains package/distribution readiness. `check:stable-baseline` is explicitly controller-scoped operational readiness and does **not** require or select a repository.

## Gate contract

`bun run check:stable-baseline -- --controller-home <path>` (or the normal Controller Home default) now:

- resolves one Controller Home without cwd/repository selection;
- observes Canonical Runtime ownership/readiness;
- runs existing Standalone Recovery whole-Runtime verification (`verifyStableRuntime`);
- requires active/known whole-release coherence;
- requires the independent `Forge Recovery` connector descriptor to be `readyForChatGPT`;
- runs the existing public Recovery Connector E2E verifier: public health, OAuth metadata, protected-resource metadata, Bearer challenge, PKCE registration/token exchange, MCP initialize, initialized notification, tools/list and recovery read-only calls;
- emits a deterministic identity-derived receipt ID and stores immutable + latest receipts below `Controller Home/recovery/stable-baseline/`;
- exits non-zero with explicit blockers if any required recovery/runtime condition fails.

This deliberately reuses the existing Recovery Gateway/Watchdog/tunnel/OAuth implementation instead of creating another supervisor or recovery authority.

## Follow-up still required before #141 closure

- add actionable stale Work/handoff maintenance debt to the gate;
- include the primary public connector/tunnel identity binding from #136;
- include failure-injection receipts for primary Runtime/session loss and crash/restart durable Work survival;
- bind the final baseline receipt to the gate definition digest.

Related: #129 #136 #141.