### PR TITLE
ci: retire scheduled Cloud Forge fallback

### DIFF
--- a/.github/workflows/forge-cloud-maintainer.yml
+++ b/.github/workflows/forge-cloud-maintainer.yml
@@ -1,15 +1,12 @@
-name: Forge Cloud Maintainer
+name: Forge Cloud Maintainer (manual fallback)
 
 on:
   workflow_dispatch:
-  schedule:
-    # GitHub-hosted jobs cannot run forever. Renew the same dedicated tunnel
-    # before the current ~5h45m host reaches the 6h hosted-runner ceiling.
-    - cron: '17 */5 * * *'
 
+# The persistent Forge Cloud VM owns the dedicated tunnel. Keep this workflow
+# only as an explicitly invoked recovery fallback; never renew it on a schedule.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   # Never intentionally run two writers against the dedicated tunnel until


### PR DESCRIPTION
Persistent Forge Cloud is now hosted on the Google VM and cold-boot verified.

This retires the GitHub-hosted 5-hour renewal schedule, keeps the workflow as manual recovery fallback only, and reduces its default permissions to read-only contents. The GitHub workflow is already disabled_manually and has no nonterminal runs.