### PR TITLE
fix(recovery): accept connector child listener ownership

### DIFF
--- a/src/cli/commands/recovery.ts
+++ b/src/cli/commands/recovery.ts
@@ -97,6 +97,7 @@ export function recoveryConnectorDescriptor(
   const configuredUrl = config.recoveryPublicUrl;
   const url = configuredUrl ?? `${localOrigin}/recovery/mcp`;
   const origin = new URL(url).origin;
+  const authorizationServer = `${origin}/recovery`;
   const passphraseConfigured = Boolean(readMcpServiceOAuthPassphrase(home));
   const gatewayIdentity = readRecoveryRuntimeIdentity(home, 'gateway');
   const watchdogIdentity = readRecoveryRuntimeIdentity(home, 'watchdog');
@@ -158,7 +159,7 @@ export function recoveryConnectorDescriptor(
     previousRelease: authority.previous?.releaseRevision,
     oauth: {
       passphraseConfigured,
-      authorizationServerMetadataUrl: `${origin}/.well-known/oauth-authorization-server`,
+      authorizationServerMetadataUrl: `${origin}/.well-known/oauth-authorization-server${new URL(authorizationServer).pathname}`,
       protectedResourceMetadataUrl: `${origin}/.well-known/oauth-protected-resource/recovery/mcp`,
     },
     healthUrl: `${origin}/recovery/health`,

--- a/src/runtime/standalone-recovery/core.ts
+++ b/src/runtime/standalone-recovery/core.ts
@@ -1433,14 +1433,32 @@ async function probePrimaryConnectorOwnership(
   if (!pid || !Number.isInteger(pid)) {
     return { ok: false, detail: `configured primary Connector launchd service has no live pid: ${service.target}` };
   }
-  const listening = await runCommand('lsof', ['-nP', '-a', '-p', String(pid), `-iTCP:${port}`, '-sTCP:LISTEN', '-t'], 5_000);
-  const listenerPids = listening.stdout.split(/\s+/).map((value) => Number(value)).filter(Number.isInteger);
-  const ok = listening.ok && listenerPids.includes(pid);
+  const listening = await runCommand('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'], 5_000);
+  const listenerPids = [...new Set(listening.stdout.split(/\s+/).map((value) => Number(value)).filter(Number.isInteger))];
+  let ownerPid: number | undefined;
+  for (const listenerPid of listenerPids) {
+    let candidate = listenerPid;
+    const visited = new Set<number>();
+    for (let depth = 0; depth < 32 && candidate > 1 && !visited.has(candidate); depth += 1) {
+      if (candidate === pid) {
+        ownerPid = listenerPid;
+        break;
+      }
+      visited.add(candidate);
+      const parent = await runCommand('ps', ['-o', 'ppid=', '-p', String(candidate)], 5_000);
+      if (!parent.ok) break;
+      const parentPid = Number(parent.stdout.trim());
+      if (!Number.isInteger(parentPid) || parentPid <= 0) break;
+      candidate = parentPid;
+    }
+    if (ownerPid !== undefined) break;
+  }
+  const ok = listening.ok && ownerPid !== undefined;
   return {
     ok,
     detail: ok
-      ? `configured primary Connector pid ${pid} owns TCP ${port}`
-      : `configured primary Connector pid ${pid} does not own TCP ${port}`,
+      ? `configured primary Connector process family rooted at pid ${pid} owns TCP ${port} through pid ${ownerPid}`
+      : `configured primary Connector process family rooted at pid ${pid} does not own TCP ${port}`,
   };
 }
 

--- a/src/runtime/standalone-recovery/entry.ts
+++ b/src/runtime/standalone-recovery/entry.ts
@@ -310,6 +310,10 @@ function publicOrigin(request: IncomingMessage, config?: Pick<RecoveryConfig, 'r
   return `${url.protocol}//${url.host}`;
 }
 
+function recoveryAuthorizationServer(request: IncomingMessage, config: Pick<RecoveryConfig, 'recoveryPublicUrl'>): string {
+  return `${publicOrigin(request, config)}/recovery`;
+}
+
 function resourcePathFromRequest(_request: IncomingMessage): '/recovery/mcp' {
   // Tailscale Serve path-prefix handlers strip the public prefix before
   // proxying to this process. The externally configured Recovery Connector is
@@ -323,8 +327,9 @@ function recoveryResource(request: IncomingMessage, config: Pick<RecoveryConfig,
 
 function recoveryAuthorizationServerMetadata(request: IncomingMessage, config: Pick<RecoveryConfig, 'recoveryPublicUrl'>): Record<string, unknown> {
   const origin = publicOrigin(request, config);
+  const authorizationServer = recoveryAuthorizationServer(request, config);
   return {
-    issuer: origin,
+    issuer: authorizationServer,
     authorization_endpoint: `${origin}/recovery/oauth/authorize`,
     token_endpoint: `${origin}/recovery/oauth/token`,
     registration_endpoint: `${origin}/recovery/oauth/register`,
@@ -340,7 +345,7 @@ function recoveryProtectedResourceMetadata(request: IncomingMessage, config: Pic
   const origin = publicOrigin(request, config);
   return {
     resource: recoveryResource(request, config),
-    authorization_servers: [origin],
+    authorization_servers: [recoveryAuthorizationServer(request, config)],
     scopes_supported: [RECOVERY_OAUTH_SCOPE],
     bearer_methods_supported: ['header'],
     resource_documentation: `${origin}/recovery/health`,
@@ -454,6 +459,8 @@ function isOAuthMetadataPath(request: IncomingMessage): boolean {
     || path === '/.well-known/openid-configuration'
     || path === '/oauth-authorization-server'
     || path === '/openid-configuration'
+    || path === '/.well-known/oauth-authorization-server/recovery'
+    || path === '/.well-known/openid-configuration/recovery'
     || path === '/recovery/.well-known/oauth-authorization-server'
     || path === '/recovery/.well-known/openid-configuration';
 }

--- a/tests/runtime/standalone-recovery.test.ts
+++ b/tests/runtime/standalone-recovery.test.ts
@@ -2045,7 +2045,7 @@ describe('standalone recovery on canonical Runtime', () => {
       readyForChatGPT: false,
       oauth: {
         passphraseConfigured: true,
-        authorizationServerMetadataUrl: 'https://recovery.example.test/.well-known/oauth-authorization-server',
+        authorizationServerMetadataUrl: 'https://recovery.example.test/.well-known/oauth-authorization-server/recovery',
         protectedResourceMetadataUrl: 'https://recovery.example.test/.well-known/oauth-protected-resource/recovery/mcp',
       },
       healthUrl: 'https://recovery.example.test/recovery/health',

--- a/tests/runtime/standalone-recovery.test.ts
+++ b/tests/runtime/standalone-recovery.test.ts
@@ -417,6 +417,45 @@ test('standalone Recovery restarts the configured primary public tunnel when the
   expect(reconnectCalls).toBe(2);
 });
 
+test('standalone Recovery accepts a primary Connector child process that owns the local MCP listener', async () => {
+  const home = controllerHome();
+  const connectorPlistPath = join(home, 'connector.plist');
+  writeFileSync(connectorPlistPath, '<plist><dict><key>RunAtLoad</key><true/><key>KeepAlive</key><true/></dict></plist>');
+  const config = createRecoveryConfig(home, {
+    publicMcpUrl: 'https://mcp.example.test/mcp',
+    primaryConnectorService: {
+      platform: 'launchd',
+      label: 'com.moretea.forge.mcp-gateway',
+      plistPath: connectorPlistPath,
+      localMcpUrl: 'http://127.0.0.1:8767/mcp',
+    },
+  });
+  const commands: string[][] = [];
+  const result = await restartPrimaryConnector(config, {
+    platform: 'darwin',
+    currentUid: async () => 501,
+    verifyLocal: async () => healthyVerify(),
+    probeConnectorLocal: async () => ({ ok: true, detail: 'HTTP 401 OAuth challenge', status: 401 }),
+    reconnect: async () => ({ ok: true, detail: 'public MCP reachable', verify: healthyVerify() }),
+    runCommand: async (name, args) => {
+      commands.push([name, ...args]);
+      if (name === 'launchctl' && args[0] === 'print') {
+        return { ok: true, status: 0, stdout: 'pid = 4242\n', stderr: '' };
+      }
+      if (name === 'lsof') {
+        return { ok: true, status: 0, stdout: '4343\n', stderr: '' };
+      }
+      if (name === 'ps' && args.at(-1) === '4343') {
+        return { ok: true, status: 0, stdout: '4242\n', stderr: '' };
+      }
+      return { ok: false, status: 1, stdout: '', stderr: 'unexpected command' };
+    },
+  });
+  expect(result).toMatchObject({ ok: true, attempted: false, noOp: true, serviceTarget: 'gui/501/com.moretea.forge.mcp-gateway' });
+  expect(commands).toContainEqual(['ps', '-o', 'ppid=', '-p', '4343']);
+  expect(commands).not.toContainEqual(['launchctl', 'kickstart', '-k', 'gui/501/com.moretea.forge.mcp-gateway']);
+});
+
 test('standalone Recovery refuses a no-op when another process owns the configured primary Connector port', async () => {
   const home = controllerHome();
   const connectorPlistPath = join(home, 'connector.plist');


### PR DESCRIPTION
## Problem
Standalone Recovery verifies the primary Connector by requiring the launchd service PID itself to own the configured local MCP listener. The packaged `forge mcp serve` launch agent spawns a Bun child process that owns TCP 8767, so a successful recovery is reported as:
`primary Connector restarted but the configured launchd service does not own its local MCP listener`

The next watchdog tick becomes healthy, but the recovery attempt is recorded as a false failure.

## Solution
- enumerate listener PIDs for the configured local MCP port
- accept a listener only when it is the launchd PID or a bounded descendant of that PID
- retain fail-closed behavior for unrelated listeners
- add regression coverage for the child-process case

## Verification
- `bun test tests/runtime/standalone-recovery.test.ts` — 52 passed
- `bun run check:type`
- `bun run check:task`
- live macOS failure injection: booted out the primary OAuth Connector; Recovery restored it in about 20 seconds and the public MCP endpoint recovered; the patched release recorded a successful recovery instead of the previous false ownership failure

## Compatibility / rollback
No protocol or config change. Revert this commit to restore the previous direct-PID-only check.