### PR TITLE
fix(recovery): support path-scoped OAuth discovery and verification

### DIFF
--- a/src/cli/commands/recovery.ts
+++ b/src/cli/commands/recovery.ts
@@ -254,6 +254,7 @@ export async function verifyRecoveryConnector(
   if (!connector.public) failures.push('readiness: Recovery Connector does not have an HTTPS public endpoint.');
 
   const origin = new URL(connector.url).origin;
+  const authorizationServer = `${origin}/recovery`;
   try {
     const response = await request(connector.healthUrl, { headers: { accept: 'application/json' } });
     const body = await responseJson(response);
@@ -273,7 +274,7 @@ export async function verifyRecoveryConnector(
     const response = await request(connector.oauth.authorizationServerMetadataUrl, { headers: { accept: 'application/json' } });
     const body = await responseJson(response);
     const ok = response.status === 200
-      && body.issuer === origin
+      && body.issuer === authorizationServer
       && body.authorization_endpoint === `${origin}/recovery/oauth/authorize`
       && body.token_endpoint === `${origin}/recovery/oauth/token`
       && body.registration_endpoint === `${origin}/recovery/oauth/register`;
@@ -287,7 +288,7 @@ export async function verifyRecoveryConnector(
     const response = await request(connector.oauth.protectedResourceMetadataUrl, { headers: { accept: 'application/json' } });
     const body = await responseJson(response);
     const authorizationServers = Array.isArray(body.authorization_servers) ? body.authorization_servers : [];
-    const ok = response.status === 200 && body.resource === connector.url && authorizationServers.includes(origin);
+    const ok = response.status === 200 && body.resource === connector.url && authorizationServers.includes(authorizationServer);
     probes.protectedResourceMetadata = { ok, status: response.status };
     if (!ok) failures.push('protectedResourceMetadata: OAuth protected-resource metadata is incomplete or inconsistent.');
   } catch (error) {

--- a/src/cli/commands/recovery.ts
+++ b/src/cli/commands/recovery.ts
@@ -97,6 +97,7 @@ export function recoveryConnectorDescriptor(
   const configuredUrl = config.recoveryPublicUrl;
   const url = configuredUrl ?? `${localOrigin}/recovery/mcp`;
   const origin = new URL(url).origin;
+  const authorizationServer = `${origin}/recovery`;
   const passphraseConfigured = Boolean(readMcpServiceOAuthPassphrase(home));
   const gatewayIdentity = readRecoveryRuntimeIdentity(home, 'gateway');
   const watchdogIdentity = readRecoveryRuntimeIdentity(home, 'watchdog');
@@ -158,7 +159,7 @@ export function recoveryConnectorDescriptor(
     previousRelease: authority.previous?.releaseRevision,
     oauth: {
       passphraseConfigured,
-      authorizationServerMetadataUrl: `${origin}/.well-known/oauth-authorization-server`,
+      authorizationServerMetadataUrl: `${origin}/.well-known/oauth-authorization-server${new URL(authorizationServer).pathname}`,
       protectedResourceMetadataUrl: `${origin}/.well-known/oauth-protected-resource/recovery/mcp`,
     },
     healthUrl: `${origin}/recovery/health`,

--- a/src/runtime/standalone-recovery/entry.ts
+++ b/src/runtime/standalone-recovery/entry.ts
@@ -310,6 +310,10 @@ function publicOrigin(request: IncomingMessage, config?: Pick<RecoveryConfig, 'r
   return `${url.protocol}//${url.host}`;
 }
 
+function recoveryAuthorizationServer(request: IncomingMessage, config: Pick<RecoveryConfig, 'recoveryPublicUrl'>): string {
+  return `${publicOrigin(request, config)}/recovery`;
+}
+
 function resourcePathFromRequest(_request: IncomingMessage): '/recovery/mcp' {
   // Tailscale Serve path-prefix handlers strip the public prefix before
   // proxying to this process. The externally configured Recovery Connector is
@@ -323,8 +327,9 @@ function recoveryResource(request: IncomingMessage, config: Pick<RecoveryConfig,
 
 function recoveryAuthorizationServerMetadata(request: IncomingMessage, config: Pick<RecoveryConfig, 'recoveryPublicUrl'>): Record<string, unknown> {
   const origin = publicOrigin(request, config);
+  const authorizationServer = recoveryAuthorizationServer(request, config);
   return {
-    issuer: origin,
+    issuer: authorizationServer,
     authorization_endpoint: `${origin}/recovery/oauth/authorize`,
     token_endpoint: `${origin}/recovery/oauth/token`,
     registration_endpoint: `${origin}/recovery/oauth/register`,
@@ -340,7 +345,7 @@ function recoveryProtectedResourceMetadata(request: IncomingMessage, config: Pic
   const origin = publicOrigin(request, config);
   return {
     resource: recoveryResource(request, config),
-    authorization_servers: [origin],
+    authorization_servers: [recoveryAuthorizationServer(request, config)],
     scopes_supported: [RECOVERY_OAUTH_SCOPE],
     bearer_methods_supported: ['header'],
     resource_documentation: `${origin}/recovery/health`,
@@ -454,6 +459,8 @@ function isOAuthMetadataPath(request: IncomingMessage): boolean {
     || path === '/.well-known/openid-configuration'
     || path === '/oauth-authorization-server'
     || path === '/openid-configuration'
+    || path === '/.well-known/oauth-authorization-server/recovery'
+    || path === '/.well-known/openid-configuration/recovery'
     || path === '/recovery/.well-known/oauth-authorization-server'
     || path === '/recovery/.well-known/openid-configuration';
 }

--- a/tests/runtime/standalone-recovery.test.ts
+++ b/tests/runtime/standalone-recovery.test.ts
@@ -2052,7 +2052,7 @@ describe('standalone recovery on canonical Runtime', () => {
       readyForChatGPT: false,
       oauth: {
         passphraseConfigured: true,
-        authorizationServerMetadataUrl: 'https://recovery.example.test/.well-known/oauth-authorization-server',
+        authorizationServerMetadataUrl: 'https://recovery.example.test/.well-known/oauth-authorization-server/recovery',
         protectedResourceMetadataUrl: 'https://recovery.example.test/.well-known/oauth-protected-resource/recovery/mcp',
       },
       healthUrl: 'https://recovery.example.test/recovery/health',


### PR DESCRIPTION
## Summary

- publish Recovery OAuth authorization-server metadata at the path-scoped well-known URL
- advertise the path-scoped Recovery issuer from protected-resource metadata and Bearer challenges
- verify the same path-scoped issuer in `forge recovery verify-connector`

## Validation

- `bun test tests/runtime/standalone-recovery.test.ts` (52 passed)
- `bun run check:type`
- live `forge recovery verify-connector` against a Forge 1.7.0 Recovery deployment, including OAuth PKCE, MCP initialize, tools/list, runtime_status, and list_releases